### PR TITLE
docs(PN): fold April 2026 modular-architecture decision into canonical docs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,12 +1,12 @@
 # burnt — Technical Specification
 
-> Notebook quality and cost analysis for Databricks. Like ruff, but for your notebooks.
+> Cost Compiler for Spark. Per-operation, per-table, per-dollar.
 
 ---
 
 ## 1. Product
 
-burnt is a static analysis and runtime enrichment tool for Databricks notebooks. Its three modes in priority order:
+burnt is a static analysis and runtime enrichment tool for Spark pipelines. Works on Databricks today; EMR, Glue, Dataproc, and on-prem Spark next. Its three modes in priority order:
 
 1. **CLI static lint** — `burnt check ./notebook.py` finds expensive patterns without running any code
 2. **Interactive coaching** — attach to a Spark session, run your code, call `burnt.check()` for runtime-enriched findings
@@ -15,8 +15,9 @@ burnt is a static analysis and runtime enrichment tool for Databricks notebooks.
 It combines:
 
 - **Static analysis** (Rust engine) — parses Python/SQL code, builds a cost graph, 84 lint rules across 6 categories
-- **Runtime enrichment** — sparkMeasure captures actual stage metrics (shuffle, spill, CPU) and correlates them to graph nodes
-- **Actionable findings** — every warning includes a specific fix
+- **Runtime enrichment** — sparkMeasure (core dep) captures actual stage metrics (shuffle, spill, CPU) and correlates them to graph nodes
+- **Pricing backends** (optional extras) — map compute-seconds to dollars via cloud-specific rates: `[azure-databricks]`, `[aws-databricks]`, `[gcp-databricks]`, `[onprem-spark]`
+- **Actionable findings** — every warning includes a specific fix; autofixable rules support `--fix` / `--unsafe-fixes`
 
 ### Output
 
@@ -52,13 +53,13 @@ $ burnt check ./notebooks/pipeline.py
 
 ## 2. Philosophy
 
-1. **Databricks-first.** The lint rules work without credentials. Cost intelligence requires Databricks. Be honest about it.
+1. **Spark-generic.** Lint rules and compute-seconds work on any Spark code. Dollar estimates require a cloud pricing extra. Be honest about which is which.
 2. **CLI-first.** `burnt check` is the product. The Python API is a second mode.
-3. **Full notebook hygiene.** Cost rules + style rules + structure rules. "ruff for Databricks notebooks."
-4. **Static + runtime.** Static rules always run. sparkMeasure enriches them when a Spark session is active.
-5. **Compute seconds over dollars.** "8.3 executor-hours" is actionable everywhere. Backends optionally map to USD.
+3. **Full notebook hygiene.** Cost rules + style rules + structure rules. "ruff for Databricks notebooks, and beyond."
+4. **Static + runtime.** Static rules always run. sparkMeasure (core dep) enriches them when a Spark session is active.
+5. **Compute seconds over dollars.** "8.3 executor-hours" is actionable everywhere. Pricing backends map to USD.
 6. **Honest confidence.** "Observed 50GB shuffle" is shown differently from "Estimated 50GB shuffle."
-7. **Graceful degradation.** No credentials → 84 lint rules. Spark session → runtime enrichment. `pip install burnt[databricks]` → dollar estimates.
+7. **Graceful degradation.** No credentials → 84 lint rules + compute-seconds. Spark session → runtime enrichment. Pricing extra → dollar estimates. Never a hard failure.
 
 ---
 
@@ -144,9 +145,14 @@ Adds dollar estimates, system table queries, and DESCRIBE DETAIL enrichment. Lin
 
 **Runtime capture** (`runtime/sparkmeasure.py`): `burnt.start_session()` initialises `StageMetrics(spark)`. At `check()` time, calls `metrics.end()` then `metrics.create_df().collect()` to get per-stage data. Falls back to Spark REST API (`localhost:4040`) if sparkMeasure is not installed.
 
-**Backend** (`burnt.runtime`): Optional protocol for enriching with cloud-specific data.
-- `SparkBackend`: generic SparkSession introspection (REST API, event log)
-- `DatabricksBackend`: `pip install burnt[databricks]` — adds DESCRIBE DETAIL, system tables, DBU pricing
+**Pricing backends** (`burnt.core.pricing.PricingBackend` protocol): Optional extras that map compute-seconds to dollars.
+- `[databricks]` — workspace API client + system-table reader (no pricing data; auto-pulled by every `[*-databricks]` extra)
+- `[azure-databricks]` — Azure DBU rates × Azure VM SKU prices × cluster profile lookup
+- `[aws-databricks]` — AWS DBU rates × EC2 instance prices
+- `[gcp-databricks]` — GCP DBU rates × GCE machine type prices
+- `[onprem-spark]` — user-supplied `$/vCPU-hour`, `$/GB-hour`, `$/GB-shuffle` from `burnt.toml`; no cloud SDK
+
+Without any pricing extra, `result.cost_estimate.usd` is `None` and only compute-seconds are reported.
 
 ---
 
@@ -161,7 +167,7 @@ burnt.start_session()
 Internally:
 
 ```python
-from sparkmeasure import StageMetrics   # pip install burnt[spark]
+from sparkmeasure import StageMetrics   # core dep — always installed
 
 spark = SparkSession.getActiveSession()
 _SESSION = StageMetrics(spark)
@@ -171,8 +177,8 @@ _SESSION.begin()
 If sparkMeasure is not installed, falls back to polling the Spark REST API at `spark.sparkContext.uiWebUrl + "/api/v1/..."`. If no Spark session is active, `start_session()` returns silently — static analysis still works.
 
 **Fallback hierarchy:**
-1. sparkMeasure (`pip install burnt[spark]`) — native Scala listener, full per-stage data *(primary)*
-2. Spark REST API (`localhost:4040`) — post-execution, no install needed *(fallback)*
+1. sparkMeasure (core dep, always installed) — native Scala listener, full per-stage data *(primary)*
+2. Spark REST API (`localhost:4040`) — post-execution, no additional install needed *(fallback)*
 3. Event log (`--event-log <path>`) — fully offline, batch use *(CLI flag)*
 
 ### 2. Run
@@ -291,18 +297,21 @@ collect() (L67)    2.1 hr    15%      Add limit
 repartition(L89)   0.8 hr    6%       Remove or increase
 ```
 
-### Backend Mapping (Optional)
+### Pricing Backend Mapping (Optional Extras)
 
-With `pip install burnt[databricks]`, compute seconds are mapped to dollar estimates via DBU rates.
+A `PricingBackend` extra maps compute-seconds to dollar estimates. Without one, `result.cost_estimate.usd` is `None`.
 
 ```python
-result.cost_estimate  # CostEstimate with USD if DatabricksBackend is active
+result.cost_estimate  # CostEstimate with USD if a pricing backend extra is active
 ```
 
 | Setup | Output |
 |-------|--------|
-| Core only | compute seconds |
-| `burnt[databricks]` | compute seconds + USD estimate |
+| Core only | compute-seconds |
+| `burnt[onprem-spark]` | compute-seconds + USD from user-supplied rates |
+| `burnt[azure-databricks]` | compute-seconds + USD via Azure DBU + VM pricing |
+| `burnt[aws-databricks]` | compute-seconds + USD via AWS DBU + EC2 pricing |
+| `burnt[gcp-databricks]` | compute-seconds + USD via GCP DBU + GCE pricing |
 
 ---
 
@@ -340,23 +349,67 @@ Collapsible sections per finding. Bar chart of compute by operation. Click to ju
 
 ---
 
-## 10. Databricks Optional Module
+## 10. Pricing Backends
+
+Dollar estimates are provided by optional pricing-backend extras. Core ships nothing pricing-shaped — without an extra, `result.cost_estimate.usd` is `None` and only compute-seconds are reported.
+
+### `[databricks]` — workspace API client + system-table reader
 
 `pip install burnt[databricks]`
 
-Adds:
-- `DatabricksBackend` — DESCRIBE DETAIL enrichment, system table queries
-- DBU pricing and dollar estimates
-- DLT pipeline graph analysis
+Provides:
+- Workspace API client for DESCRIBE DETAIL enrichment
+- System-table reader (four bounded uses: DBU rate lookup, table-size enrichment, cluster profile resolution, opt-in last-run cost)
+- Auto-installed as a transitive dep of every `[*-databricks]` pricing extra
+
+Does **not** implement `PricingBackend`. Dollar estimates are in the cloud-specific extras below.
+
+### `[azure-databricks]`, `[aws-databricks]`, `[gcp-databricks]`
+
+`pip install burnt[azure-databricks]`  *(auto-pulls `[databricks]`)*
+
+Each implements `PricingBackend` with cloud-specific DBU rates and VM/instance pricing:
+- Azure: Azure DBU rates × Azure VM SKU prices (Azure Retail Prices API)
+- AWS: AWS DBU rates × EC2 instance prices (AWS Pricing API or shipped tables)
+- GCP: GCP DBU rates × GCE machine type prices (Cloud Billing Catalog API)
 
 ```python
-import burnt  # core 84 rules work immediately
-# With databricks extra, check() is enriched with dollar estimates
+import burnt  # core 84 rules + compute-seconds always work
 result = burnt.check()
-result.cost_estimate.estimated_cost_usd  # available if DatabricksBackend is active
+result.cost_estimate.usd  # available when a [*-databricks] extra is installed and credentials are present
 ```
 
-Works without credentials — lint rules run regardless. Credentials unlock cost estimates.
+### `[onprem-spark]` — self-hosted Spark pricing
+
+`pip install burnt[onprem-spark]`  *(no cloud SDK dependency)*
+
+Implements `PricingBackend` from `burnt.toml` user-supplied rates:
+
+```toml
+[burnt.onprem_spark]
+cost_per_vcpu_hour   = 0.048
+cost_per_gb_hour     = 0.006
+cost_per_gb_shuffle  = 0.001
+```
+
+Zero external dependencies. Highest reach for non-Databricks Spark users.
+
+### `PricingBackend` protocol
+
+```python
+# src/burnt/core/pricing.py
+class PricingBackend(Protocol):
+    name: str                                        # "azure-databricks", "onprem-spark", ...
+    def map(self, graph: CostGraph) -> CostEstimate: # compute-seconds → $$
+        ...
+```
+
+When multiple pricing extras are installed, select one via `burnt.toml`:
+
+```toml
+[burnt.pricing]
+backend = "azure-databricks"
+```
 
 ---
 
@@ -374,19 +427,42 @@ Same as ruff/black: walk up from target path looking for:
 ### `burnt.toml`
 
 ```toml
-[check]
+[lint]
 select = ["BP*", "BD*"]   # only run these rule prefixes/IDs (default: all)
 ignore = ["BNT_001"]      # skip specific rules
-severity = "warning"       # minimum severity to report (error|warning|note)
+fail-on = "warning"        # minimum severity to exit non-zero (error|warning|info)
 max_cost = 50.0            # fail if total compute exceeds N executor-hours
 
 [display]
 format = "auto"            # "auto" | "terminal" | "notebook"
 
-# Only used when burnt[databricks] is installed:
-[connection]
-warehouse_id = "abc123"
+# Pricing backend selection (when multiple extras are installed):
+[burnt.pricing]
+backend = "azure-databricks"   # options: azure-databricks | aws-databricks | gcp-databricks | onprem-spark
+                               # default: auto (single installed backend wins; error if ambiguous)
+
+# On-prem / self-hosted Spark pricing (requires pip install burnt[onprem-spark]):
+[burnt.onprem_spark]
+cost_per_vcpu_hour   = 0.048   # $/vCPU-hour
+cost_per_gb_hour     = 0.006   # $/GB-hour memory
+cost_per_gb_shuffle  = 0.001   # $/GB shuffled
+
+# Databricks system-table path overrides (requires pip install burnt[databricks]):
+[burnt.databricks.system_tables]
+enabled                   = true   # master switch; false = never query system tables
+# Defaults shown; override for orgs that mirror system tables into private schemas:
+# query_history             = "system.query.history"
+# billing_usage             = "system.billing.usage"
+# list_prices               = "system.billing.list_prices"
+# information_schema_tables = "system.information_schema.tables"
+# compute_clusters          = "system.compute.clusters"
+# node_timeline             = "system.compute.node_timeline"
 ```
+
+System-table behaviour rules:
+1. If a configured table is unreadable (permissions, doesn't exist), burnt logs once at `INFO` and falls back silently. It never errors — system tables are an enrichment, not a requirement.
+2. Paths are resolved once per `burnt.check()` call and cached on the result.
+3. `burnt doctor` reports which system tables are reachable for the current config.
 
 ---
 
@@ -525,12 +601,19 @@ dependencies = [
     "rich>=13.0",
     "typer>=0.15",
     "pyyaml>=6.0",
+    "tabulate>=0.9,<1",
+    "sparkmeasure>=2.0",      # runtime metric capture (core — fundamental to honest confidence)
+    "libcst>=1.0,<2",         # --fix / --unsafe-fixes Python rewrites (core CLI flag)
 ]
 
 [project.optional-dependencies]
-databricks = ["databricks-sdk>=0.50.0"]
-alerts = ["slack-sdk>=3.0"]
-all = ["burnt[databricks,alerts]"]
+notebook        = ["jinja2>=3,<4"]                                      # HTML rendering + .dbc parsing
+databricks      = ["databricks-sdk>=0.50,<1", "requests>=2.32,<3"]     # workspace API + system tables
+azure-databricks = ["burnt[databricks]"]                                # Azure DBU + VM pricing
+aws-databricks   = ["burnt[databricks]"]                                # AWS DBU + EC2 pricing
+gcp-databricks   = ["burnt[databricks]"]                                # GCP DBU + GCE pricing
+onprem-spark     = []                                                   # user-supplied $/vCPU-hour rates
+all = ["burnt[notebook,databricks,azure-databricks,aws-databricks,gcp-databricks,onprem-spark]"]
 ```
 
 ---
@@ -542,13 +625,14 @@ src/burnt/
 ├── __init__.py            # start_session(), check(), version()
 ├── _check/
 │   └── __init__.py        # check() orchestration: static → runtime → merge
-├── _config.py             # Config loading: burnt.toml + env + args
-├── _session.py            # sparkMeasure wrapper + REST fallback
+├── _config/               # Config loading: burnt.toml + env + args
+├── _session.py            # sparkMeasure wrapper + REST fallback (core)
 ├── core/
 │   ├── cache.py           # TTL cache
 │   ├── config.py          # BurntConfig (Pydantic settings)
-│   ├── exceptions.py      # BurntError, ConfigError
+│   ├── exceptions.py      # BurntError, ConfigError, NotAvailableError
 │   ├── models.py          # Finding, CheckResult, CostEstimate
+│   ├── pricing.py         # PricingBackend protocol
 │   └── protocols.py       # Backend protocol
 ├── graph/
 │   ├── model.py           # CostGraph, CostNode
@@ -557,22 +641,27 @@ src/burnt/
 ├── runtime/
 │   ├── backend.py         # Backend protocol
 │   ├── spark_backend.py   # Generic SparkSession + REST API backend
-│   ├── sparkmeasure.py    # StageMetrics wrapper (pip install burnt[spark])
+│   ├── sparkmeasure.py    # StageMetrics wrapper (core dep)
 │   └── event_log.py       # Event log parser (--event-log flag)
 ├── parsers/
 │   ├── explain.py         # EXPLAIN EXTENDED output parsing
-│   ├── notebooks.py       # Jupyter / Databricks notebook parsing
+│   ├── notebooks.py       # Jupyter / Databricks notebook parsing (.py, .sql, .ipynb)
+│   ├── dbc.py             # .dbc archive parser [notebook] extra
 │   └── antipatterns.py    # AntiPattern dataclass + Rust bridge
 ├── display/
-│   ├── terminal.py        # Rich table output
-│   ├── notebook.py        # HTML output
-│   └── export.py          # JSON, Markdown, SARIF 2.1.0 export
+│   ├── terminal.py        # Rich table output (core)
+│   ├── notebook.py        # HTML output [notebook] extra — raises NotAvailableError if absent
+│   └── export.py          # JSON, Markdown, SARIF 2.1.0 export (core)
 ├── cli/
-│   └── main.py            # check, rules, init, doctor, cache
-└── databricks/            # pip install burnt[databricks]
-    ├── backend.py         # DatabricksBackend (system tables, DESCRIBE DETAIL)
-    ├── pricing/           # DBU rates, dollar estimates
-    └── cli.py             # Databricks-specific CLI commands
+│   └── main.py            # check (+ --fix/--unsafe-fixes/--diff), rules, init, doctor, cache
+├── databricks/            # pip install burnt[databricks] — workspace API + system tables (no pricing)
+│   ├── backend.py         # DatabricksBackend (system tables, DESCRIBE DETAIL)
+│   └── cli.py             # Databricks-specific CLI commands
+└── cloud/                 # pricing-backend extras (one sub-package per backend)
+    ├── azure_databricks/  # [azure-databricks] — Azure DBU + VM pricing
+    ├── aws_databricks/    # [aws-databricks] — AWS DBU + EC2 pricing
+    ├── gcp_databricks/    # [gcp-databricks] — GCP DBU + GCE pricing
+    └── onprem_spark/      # [onprem-spark] — user-supplied $/vCPU-hour rates
 ```
 
 ---
@@ -583,7 +672,7 @@ src/burnt/
 import burnt
 
 # ── Session (optional — enables runtime enrichment) ──
-burnt.start_session()    # requires active SparkSession + pip install burnt[spark]
+burnt.start_session()    # requires active SparkSession (sparkMeasure is a core dep)
 
 # ... run your Spark code ...
 
@@ -604,13 +693,13 @@ result.to_sarif()         # SARIF 2.1.0 dict
 
 ## 17. Design Principles
 
-1. **Databricks-first.** Lint rules work without credentials. Cost intelligence requires Databricks. No pretending otherwise.
+1. **Spark-generic.** Lint rules and compute-seconds work on any Spark code. Cost-in-dollars requires a pricing-backend extra. No pretending otherwise.
 2. **CLI-first.** `burnt check` is the product. The Python API is a second mode.
 3. **Full notebook hygiene.** Cost + style + structure rules. No artificial scope limit.
-4. **Static + runtime.** Static rules always run. sparkMeasure enriches when a session is active.
-5. **Compute seconds over dollars.** Actionable everywhere. Backends map to USD.
+4. **Static + runtime.** Static rules always run. sparkMeasure (core) enriches when a session is active.
+5. **Compute seconds over dollars.** Actionable everywhere. Pricing backends map to USD.
 6. **Honest confidence.** Mark observed data differently from estimates.
-7. **Graceful degradation.** No creds → 84 rules. Spark session → enrichment. Databricks → dollar estimates. Never a hard failure.
+7. **Graceful degradation.** No creds → 84 rules + compute-seconds. Spark session → enrichment. Pricing extra → dollar estimates. Never a hard failure.
 
 ---
 
@@ -621,8 +710,9 @@ result.to_sarif()         # SARIF 2.1.0 dict
 | P0 Base Rework | done | Cleanup, new package structure |
 | P1 Rust Engine | done | tree-sitter, CostGraph, 84 rules, PyO3 bridge |
 | PX Design Alignment | **in progress** | Dead code removal, sparkMeasure session, docs |
-| P2 CLI Completion | todo | Rewire `check` to `_check.run()`, SARIF, event log |
-| P3 Databricks Module | todo | `burnt[databricks]`: dollar estimates, system tables |
-| P4 CI Integration | todo | Pre-commit, GitHub Actions, DABs examples |
-| P5 Hardening | todo | E2E tests, error audit, packaging |
+| PN Modular Architecture | todo | Pricing backends, `[notebook]` extra, `--fix`/`--diff`, config schema |
+| P2 Session & Intelligence | todo | Cost estimation, EXPLAIN enrichment (unblocked after PX) |
+| P3 CLI Completion | todo | Rewire `check` to `_check.run()`, SARIF, event log |
+| P4 Databricks Backend | todo | `burnt[databricks]` + `[*-databricks]` extras: system tables, dollar estimates |
+| P5 Integration & Hardening | todo | E2E tests, CI examples, error audit, packaging |
 | P6 Validation | todo | Dogfood, security audit, ship v0.2.0 |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img src="public/logo_text.svg" alt="burnt" width="400">
 </picture>
 
-**Cost Compiler for Databricks**
+**Cost Compiler for Spark**
 
 Per-operation, per-table, per-dollar.
 
@@ -17,9 +17,9 @@ Per-operation, per-table, per-dollar.
 
 ---
 
-## What is this?
+burnt parses Spark pipelines — Python, SQL, or DLT/SDP — and shows you what each operation costs: statically before the job runs, with live metrics while it runs, and as a CI gate before it ships.
 
-`burnt` parses Databricks notebooks — Python, SQL, or DLT — builds a cost graph, and shows you what each operation costs.
+Works on **Databricks today**. EMR, Glue, Dataproc, and on-prem Spark next.
 
 ```python
 import burnt
@@ -55,11 +55,11 @@ daily_pipeline.py  │  Python  │  6 cells  │  2 via %run
 
 Auto-detected. One command.
 
-**Python** — per-operation cost. DataFrames traced across `%run` chains.
+**Static lint** — run offline, no credentials, no Spark. 84 rules fire immediately.
 
-**SQL** — per-statement cost. CREATE TABLE AS, MERGE INTO, OPTIMIZE decomposed. Cross-cell table deps.
+**In-notebook coaching** — attach to a live Spark session; `burnt.check()` correlates actual stage metrics to your source lines.
 
-**DLT / SDP** — per-table cost. Streaming vs materialized views. DLT tier pricing.
+**CI gate** — block PRs on cost regressions or lint errors using `--output sarif` or `--max-cost`.
 
 ```
 orders_pipeline.py  │  DLT PRO  │  3 tables
@@ -81,21 +81,39 @@ orders_pipeline.py  │  DLT PRO  │  3 tables
 pip install burnt
 ```
 
-Databricks:
+Inside Databricks:
+
 ```
 %pip install burnt
 ```
 
-Works without credentials — 84 lint rules run immediately. Add `pip install burnt[databricks]` for cost estimation and dollar figures.
+> **Current status (v0.2.0-dev):** Static lint (84 rules) and CostGraph (compute-seconds)
+> are fully operational. Live sparkMeasure runtime capture is wired but in active
+> development (PX/02). Dollar estimates require a pricing-backend extra (Phase N).
+
+### Install matrix
+
+| Install | Lint (84 rules) | Compute-seconds | Live runtime | Dollars | System-table enrichment | HTML / .dbc |
+|---------|:--------------:|:---------------:|:------------:|:-------:|:----------------------:|:-----------:|
+| `pip install burnt` | ✅ + `--fix` + `--diff` | ✅ | ✅ core | ❌ | ❌ | ❌ |
+| `+ [onprem-spark]` | ✅ | ✅ | ✅ | ✅ user-supplied rates | ❌ | ❌ |
+| `+ [databricks]` alone | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
+| `+ [azure-databricks]` | ✅ | ✅ | ✅ | ✅ Azure DBU + VM | ✅ | ❌ |
+| `+ [aws-databricks]` | ✅ | ✅ | ✅ | ✅ AWS DBU + EC2 | ✅ | ❌ |
+| `+ [gcp-databricks]` | ✅ | ✅ | ✅ | ✅ GCP DBU + GCE | ✅ | ❌ |
+| `+ [notebook]` | ✅ | ✅ | ✅ | per other extras | per other extras | ✅ |
+| `[all]` | ✅ | ✅ | ✅ | ✅ selected backend | ✅ | ✅ |
+
+Every `[*-databricks]` extra auto-pulls `[databricks]` (workspace API + system tables). `[onprem-spark]` is self-contained — configure your own `$/vCPU-hour` in `burnt.toml`.
 
 ---
 
-## Notebook
+## Notebook API
 
 ```python
 import burnt
 
-burnt.start_session()   # attach sparkMeasure; requires pip install burnt[spark]
+burnt.start_session()   # attach sparkMeasure to the active SparkSession
 
 # ... run your Spark code ...
 
@@ -105,6 +123,7 @@ result.findings         # list[Finding]
 result.to_json()        # dict
 result.to_markdown()    # str
 result.to_sarif()       # SARIF 2.1.0 dict
+result.to_html()        # requires pip install burnt[notebook]
 ```
 
 ## CLI
@@ -117,39 +136,44 @@ burnt check ./notebooks/ --output sarif > burnt.sarif
 burnt check ./notebooks/ --max-cost 25
 burnt check ./notebooks/ --select BP* --ignore BNT_*
 
+# Autofix (ruff-style)
+burnt check ./notebooks/ --fix
+burnt check ./notebooks/ --unsafe-fixes
+
+# Diff-aware lint — only files changed since main
+burnt check ./notebooks/ --diff main
+
 burnt rules                     # Browse all 84 rules (interactive TUI)
 burnt init                      # Generate burnt.toml
-burnt doctor                    # Check config and connectivity
+burnt doctor                    # Check config, Spark availability, system-table access
 ```
 
 ---
 
 ## Config
 
-Standalone `burnt.toml`, or `[tool.burnt]` in `pyproject.toml` — same as ruff.
+Standalone `burnt.toml`, or `[tool.burnt]` in `pyproject.toml` — same discovery as ruff.
 
 **`burnt.toml`:**
 ```toml
-[check]
+[lint]
 ignore = ["BNT_001"]
-max_cost = 50.0
-severity = "warning"
-```
+fail-on = "warning"
 
-**`pyproject.toml`:**
-```toml
-[tool.burnt.check]
-ignore = ["BNT_001"]
-max_cost = 50.0
+[burnt.pricing]
+backend = "azure-databricks"   # auto if only one pricing extra installed
+
+[burnt.onprem_spark]
+cost_per_vcpu_hour  = 0.048
+cost_per_gb_hour    = 0.006
+cost_per_gb_shuffle = 0.001
+
+[burnt.databricks.system_tables]
+enabled = true   # set false to skip system-table queries entirely
+# query_history = "prod_observability.query_history"  # override if mirrored
 ```
 
 Discovery: walks up from target path looking for `burnt.toml`, `.burnt.toml`, or `pyproject.toml` with `[tool.burnt]`. Falls back to `~/.config/burnt/burnt.toml`.
-
-Priority: CLI flags > `burnt.config()` > config file > `BURNT_*` env vars > defaults.
-
-```bash
-burnt check --init    # Generate burnt.toml (or add [tool.burnt] to existing pyproject.toml)
-```
 
 ---
 
@@ -162,44 +186,43 @@ WARN   DLT001  MV could be streaming
 WARN   BSQ002  SELECT * in final SQL cell
 ```
 
-Three tiers: Tier 1 (TOML, no Rust needed), Tier 2 (Rust context), Tier 3 (Rust semantic).
-
----
-
-## Access Levels
-
-| Level | Output |
-|-------|--------|
-| Full | Graph + estimates + monitoring + alerts |
-| SparkSession only | Graph + DESCRIBE + structural findings |
-| REST only | Graph + Delta enrichment + medium confidence |
-| Auth-only | 84 lint rules |
+Three tiers: Tier 1 (TOML + tree-sitter query, no Rust needed), Tier 2 (Rust context-aware), Tier 3 (Rust semantic/dataflow). Six categories: Performance (`BP*`), SQL quality (`BQ*`, `SQ*`), Delta (`BD*`), DLT/SDP (`SDP*`), Notebook style (`BNT_*`), Notebook structure (`BB*`, `BN*`).
 
 ---
 
 ## Architecture
 
 ```
-CLI: burnt check                 Python: burnt.check()
+CLI: burnt check                 Notebook: burnt.check()
       │                                │
   Rust engine (PyO3)          Rust engine (same)
   84 rules, CostGraph         + sparkMeasure enrichment
-  tree-sitter Py/SQL/DLT      + DatabricksBackend (optional)
+  tree-sitter Py/SQL/DLT      + PricingBackend (optional)
+                                    │
+                          ┌─────────┴──────────┐
+                          │                    │
+                   [databricks]         [onprem-spark]
+                 [azure-databricks]    user $/vCPU-hour
+                 [aws-databricks]
+                 [gcp-databricks]
 ```
 
-Rust engine: tree-sitter Python + SQL, `%run` resolution, mode detection, semantic model, CostGraph, 84 rules across 6 categories.
-Python: sparkMeasure session wrapper, graph enrichment, cost estimation, display, CLI.
+Rust engine: tree-sitter Python + SQL, `%run` resolution, mode detection, semantic model, CostGraph, 84 rules.
+Python: sparkMeasure session wrapper, graph enrichment, cost estimation via `PricingBackend`, display, CLI.
+Core install: zero cloud SDK, zero credentials required.
 
 ---
 
 ## Contributing
 
-Tier 1 rules = TOML + tree-sitter query. No Rust.
+Tier 1 rules = TOML + tree-sitter query. No Rust required.
 
-1. `src/burnt-engine/rules/tier1/{pyspark,sql,dlt}/BXXX_rule.toml`
+1. `src/burnt-engine/rules/{performance,sql,delta,sdp,notebook,style}/BXXX_rule.toml`
 2. Fixture in `tests/fixtures/tier1/`
 3. `cargo test tier1_rules`
 4. PR
+
+See `docs/writing-rules.md` for the full rule format including the `[fix]` section for autofixable rules.
 
 ---
 
@@ -207,7 +230,7 @@ Tier 1 rules = TOML + tree-sitter query. No Rust.
 
 ```bash
 cd src/burnt-engine && maturin develop --release && cargo test
-uv sync && uv run pytest -m unit -v && uv run ruff check src/ tests/
+uv sync --all-extras && uv run pytest -m unit -v && uv run ruff check src/ tests/
 ```
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -208,10 +208,10 @@ All pattern types (exact code, prefix, tag) work inside `[...]`.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `workspace-url` | `str \| None` | `None` | Databricks workspace URL. Overridden by `BURNT_WORKSPACE_URL`. |
-| `token` | `str \| None` | `None` | PAT token. Overridden by `BURNT_TOKEN`. |
+| `workspace-url` | `str \| None` | `None` | Databricks workspace URL. Overridden by `BURNT_WORKSPACE_URL`. Requires `pip install burnt[databricks]`. |
+| `token` | `str \| None` | `None` | PAT token. Overridden by `BURNT_TOKEN`. Requires `pip install burnt[databricks]`. |
 | `target-currency` | `str` | `"USD"` | Default currency for cost estimates. `USD` or `EUR`. |
-| `pricing-source` | `str` | `"api"` | How to fetch exchange rates. `api` uses frankfurter.app; `static` uses hardcoded rates. |
+| `pricing-source` | `str` | `"static"` | How to fetch pricing data. `static` uses shipped rate tables; `api` queries live cloud pricing APIs (requires the relevant `[*-databricks]` extra). |
 
 ---
 
@@ -288,10 +288,101 @@ From highest to lowest priority:
 
 ---
 
+## Pricing Backend Selection
+
+When multiple pricing-backend extras are installed, tell burnt which to use:
+
+```toml
+[burnt.pricing]
+backend = "azure-databricks"   # azure-databricks | aws-databricks | gcp-databricks | onprem-spark
+                               # default: auto (single installed backend wins; error if ambiguous)
+```
+
+**Env-var override:** `BURNT_PRICING_BACKEND=azure-databricks`
+
+If only one pricing extra is installed, `backend` is optional — burnt uses it automatically. If
+multiple are installed and `backend` is not configured, `burnt check` exits with a config error
+listing the installed backends and asking you to pick one.
+
+---
+
+## On-Prem / Self-Hosted Spark Rates
+
+For self-hosted Spark on Kubernetes, YARN, or standalone. Requires `pip install burnt[onprem-spark]`.
+No cloud SDK dependency — dollar estimates come entirely from the rates you configure here.
+
+```toml
+[burnt.onprem_spark]
+cost_per_vcpu_hour   = 0.048   # $/vCPU-hour  (required)
+cost_per_gb_hour     = 0.006   # $/GB-hour memory  (required)
+cost_per_gb_shuffle  = 0.001   # $/GB shuffled  (required)
+```
+
+**Env-var overrides:**
+
+| Variable | Maps to |
+|----------|---------|
+| `BURNT_ONPREM_SPARK_COST_PER_VCPU_HOUR` | `onprem_spark.cost_per_vcpu_hour` |
+| `BURNT_ONPREM_SPARK_COST_PER_GB_HOUR` | `onprem_spark.cost_per_gb_hour` |
+| `BURNT_ONPREM_SPARK_COST_PER_GB_SHUFFLE` | `onprem_spark.cost_per_gb_shuffle` |
+
+All three rates are required when `[onprem-spark]` is the active backend. `burnt check` exits
+with a config error if any rate is missing.
+
+---
+
+## Databricks System Tables
+
+*Requires `pip install burnt[databricks]`. System tables are an enrichment — burnt never errors if
+they are unavailable; it logs once at INFO and falls back to other data sources.*
+
+System-table paths can be overridden when your org mirrors them into private schemas, or when future
+Unity Catalog versions relocate them.
+
+```toml
+[burnt.databricks.system_tables]
+# Master switch — set false to skip system-table queries entirely even when [databricks] is installed.
+enabled = true
+
+# Defaults shown; override only what you need.
+# query_history             = "system.query.history"
+# billing_usage             = "system.billing.usage"
+# list_prices               = "system.billing.list_prices"
+# information_schema_tables = "system.information_schema.tables"
+# compute_clusters          = "system.compute.clusters"
+# node_timeline             = "system.compute.node_timeline"
+```
+
+**Env-var overrides** (follow existing `BURNT_*` prefix convention):
+
+| Variable | Table |
+|----------|-------|
+| `BURNT_DATABRICKS_SYSTEM_TABLES_QUERY_HISTORY` | `query_history` |
+| `BURNT_DATABRICKS_SYSTEM_TABLES_BILLING_USAGE` | `billing_usage` |
+| `BURNT_DATABRICKS_SYSTEM_TABLES_LIST_PRICES` | `list_prices` |
+| `BURNT_DATABRICKS_SYSTEM_TABLES_INFORMATION_SCHEMA_TABLES` | `information_schema_tables` |
+| `BURNT_DATABRICKS_SYSTEM_TABLES_COMPUTE_CLUSTERS` | `compute_clusters` |
+| `BURNT_DATABRICKS_SYSTEM_TABLES_NODE_TIMELINE` | `node_timeline` |
+
+**What system tables are used for** (four narrow, bounded uses — no fleet-wide mining):
+
+| Use | Table | Purpose |
+|-----|-------|---------|
+| DBU rate lookup | `list_prices` | Replaces shipped JSON of DBU rates for orgs that prefer live data |
+| Table-size enrichment | `information_schema_tables` | Fills `estimated_input_bytes` from ground truth without per-table `DESCRIBE DETAIL` |
+| Cluster profile resolution | `compute_clusters` | Resolves `cluster_id` in `burnt.toml` to node type + size |
+| Last-run observed cost | `query_history` | Opt-in: show "your last actual run cost $X" in-notebook |
+
+**Behaviour rules:**
+1. If a configured table is unreadable (permissions error, doesn't exist), burnt logs once at `INFO` and falls back to its non-system-table path (shipped JSON / `DESCRIBE DETAIL` / SDK call). It never errors.
+2. Paths are resolved once per `burnt.check()` call and cached on the result.
+3. `burnt doctor` reports which system tables are reachable for the current config, so you can verify access before relying on enrichment.
+
+---
+
 ## TableRegistry (Programmatic)
 
-Enterprise environments often expose system tables through governance views
-with custom names. Use `TableRegistry` to remap the tables burnt queries:
+For programmatic use when you need to override table paths in code rather than config:
 
 ```python
 from burnt.core.table_registry import TableRegistry
@@ -302,7 +393,7 @@ registry = TableRegistry(
     query_history="governance.cost_management.v_query_history",
 )
 
-estimate = burnt.estimate("SELECT ...", registry=registry)
+result = burnt.check(registry=registry)
 ```
 
 | Key | Default table |
@@ -315,3 +406,6 @@ estimate = burnt.estimate("SELECT ...", registry=registry)
 | `compute_node_timeline` | `system.compute.node_timeline` |
 | `lakeflow_jobs` | `system.lakeflow.jobs` |
 | `lakeflow_job_run_timeline` | `system.lakeflow.job_run_timeline` |
+
+The `[burnt.databricks.system_tables]` config section (above) is the preferred approach for
+static configuration; `TableRegistry` is for dynamic overrides in application code.

--- a/docs/modular-architecture.md
+++ b/docs/modular-architecture.md
@@ -2,6 +2,12 @@
 
 > Architecture document. Realigns the package's identity and module/extras boundaries so subsequent task work (PX, P2–P6) executes against a coherent shape. Companion to `DESIGN.md` (technical spec) and `README.md` (user-facing pitch).
 
+> **Decision status:**
+> - ✅ All decisions in this document are recorded and agreed
+> - ✅ Docs updated: `README.md`, `DESIGN.md`, `docs/configuration.md`, `tasks/README.md`
+> - ⏳ Tasks created for code implementation: `tasks/PN/01` through `tasks/PN/05`
+> - ❌ Code not yet implemented — see `tasks/PN/` for the implementation work queue
+
 ---
 
 ## Context

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "burnt"
 version = "0.2.0"
-description = "Notebook quality and cost analysis for Databricks"
+description = "Cost Compiler for Spark — per-operation, per-table cost analysis"
 readme = "README.md"
 license = "GPL-3.0-or-later"
 requires-python = ">=3.10"

--- a/tasks/PN/01-pyproject-extras-restructure.md
+++ b/tasks/PN/01-pyproject-extras-restructure.md
@@ -1,0 +1,103 @@
+# Task: pyproject.toml extras restructure
+
+---
+
+## Metadata
+
+```yaml
+id: PN-01-pyproject-extras-restructure
+status: todo
+phase: N
+priority: critical
+agent: ~
+blocked_by: [PX-01-remove-dead-code]
+created_by: planner
+```
+
+---
+
+## Context
+
+### Goal
+
+Restructure `pyproject.toml` optional extras to match the modular-architecture decision recorded in `docs/modular-architecture.md` §2.2 and §2.3. Remove the extras that no longer belong (`[sql]`, `[spark]`, `[alerts]`), promote `sparkmeasure` and `libcst` to core dependencies, and introduce the new extras (`[notebook]`, `[databricks]` repositioned, `[azure-databricks]`, `[aws-databricks]`, `[gcp-databricks]`, `[onprem-spark]`).
+
+The `[databricks]` extra is repositioned as the workspace API client + system-table reader only (no pricing data lives there). Every `[*-databricks]` pricing extra declares `[databricks]` as a dependency so it is auto-installed transitively. `[onprem-spark]` is fully self-contained (no cloud SDK).
+
+### Files to read
+
+```
+# Required
+pyproject.toml
+docs/modular-architecture.md   §2.1, §2.2, §2.3, §4
+src/burnt/__init__.py
+src/burnt/runtime/__init__.py
+
+# Reference
+DESIGN.md §14 Stack
+```
+
+### Background
+
+`sparkmeasure` is promoted to core because runtime metric capture is fundamental to the "honest confidence" pitch — the package's core value is compute-seconds, and that requires sparkMeasure to observe them. Gating it behind `[spark]` was wrong.
+
+`libcst` is promoted to core because `--fix` / `--unsafe-fixes` (PN-04) are core CLI flags, not extras.
+
+`[sql]` is removed because the Rust engine's tree-sitter SQL coverage replaces `sqlglot`.
+
+`[alerts]` is removed because result dispatch (Slack, webhooks) is an orchestration concern, not burnt's job.
+
+The `[all]` extra should reference the new complete set.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `[project.dependencies]` includes `sparkmeasure>=2.0` and `libcst>=1.0,<2`
+- [ ] `[project.optional-dependencies]` no longer contains `sql`, `spark`, or `alerts` keys
+- [ ] `[notebook]` extra defined: `jinja2>=3,<4` only
+- [ ] `[databricks]` extra: `databricks-sdk>=0.50,<1`, `requests>=2.32,<3` (unchanged content, repositioned role)
+- [ ] `[azure-databricks]` extra defined: auto-pulls `burnt[databricks]` + any Azure pricing dep (placeholder: `"burnt[databricks]"` only for now; actual pricing deps added in P4)
+- [ ] `[aws-databricks]` extra defined: auto-pulls `burnt[databricks]`
+- [ ] `[gcp-databricks]` extra defined: auto-pulls `burnt[databricks]`
+- [ ] `[onprem-spark]` extra defined: no external deps (pure config + arithmetic, self-contained)
+- [ ] `[all]` = `burnt[notebook,databricks,azure-databricks,aws-databricks,gcp-databricks,onprem-spark]`
+- [ ] `uv run python -c "import burnt"` succeeds in a clean venv with only core deps
+- [ ] `uv run ruff check src/` passes (no dead imports from removed extras)
+
+---
+
+## Verification
+
+### Commands
+
+```bash
+uv sync --all-extras
+uv run pytest -m unit -v
+uv run ruff check src/ tests/
+# Verify extras are importable
+uv run python -c "from sparkmeasure import StageMetrics; print('sparkmeasure ok')"
+uv run python -c "import libcst; print('libcst ok')"
+```
+
+### Integration Check
+
+- [ ] `pip install burnt` in a clean venv installs sparkmeasure and libcst as core deps, does not install databricks-sdk
+- [ ] `pip install burnt[azure-databricks]` installs databricks-sdk transitively (via `burnt[databricks]`)
+- [ ] `pip install burnt[onprem-spark]` does NOT install databricks-sdk
+
+---
+
+## Handoff
+
+### Result
+
+[Executor fills this in when done.]
+
+```yaml
+status: todo
+```
+
+### Blocked reason
+
+Blocked by PX-01 (remove dead code that imports `alerts`/`sql` extras). Cannot restructure extras until dead imports are gone.

--- a/tasks/PN/02-pricing-backend-protocol.md
+++ b/tasks/PN/02-pricing-backend-protocol.md
@@ -1,0 +1,119 @@
+# Task: PricingBackend protocol extraction
+
+---
+
+## Metadata
+
+```yaml
+id: PN-02-pricing-backend-protocol
+status: todo
+phase: N
+priority: high
+agent: ~
+blocked_by: [PN-01-pyproject-extras-restructure]
+created_by: planner
+```
+
+---
+
+## Context
+
+### Goal
+
+Extract a formal `PricingBackend` protocol to `src/burnt/core/pricing.py` per `docs/modular-architecture.md` §3. This creates the explicit boundary that makes "Cost Compiler for Spark" an architectural claim rather than just a tagline. Without this protocol, pricing is co-mingled with Databricks-specific code paths and there is no extensible seam for cloud-specific extras to plug into.
+
+Additionally, stub out the `src/burnt/cloud/` directory tree so Phase 4 (and future cloud extras) have a clear home. Move any existing `DatabricksPricingBackend` implementation stub out of core into `src/burnt/cloud/azure_databricks/` (stub only — actual pricing data files are added in P4).
+
+### Files to read
+
+```
+# Required
+src/burnt/core/
+src/burnt/databricks/
+src/burnt/runtime/backend.py
+docs/modular-architecture.md   §3, §2.4
+
+# Reference
+DESIGN.md §4 Architecture, §10 Pricing Backends
+```
+
+### Background
+
+**Protocol shape** (from modular-architecture.md §3):
+
+```python
+# src/burnt/core/pricing.py
+from typing import Protocol
+from burnt.core.models import CostGraph, CostEstimate
+
+class PricingBackend(Protocol):
+    name: str                                        # "azure-databricks", "onprem-spark", ...
+    def map(self, graph: CostGraph) -> CostEstimate: # compute-seconds → $$
+        ...
+```
+
+Core ships nothing pricing-shaped by default. Without a pricing extra, `result.cost_estimate.usd` is `None` and only compute-seconds are reported.
+
+**Directory stubs** to create (empty `__init__.py` only — implementations come in P4):
+
+```
+src/burnt/cloud/
+├── __init__.py
+├── azure_databricks/
+│   └── __init__.py      # will contain: AzureDatabricksPricingBackend
+├── aws_databricks/
+│   └── __init__.py      # will contain: AwsDatabricksPricingBackend
+├── gcp_databricks/
+│   └── __init__.py      # will contain: GcpDatabricksPricingBackend
+└── onprem_spark/
+    └── __init__.py      # will contain: OnPremSparkPricingBackend
+```
+
+The `[databricks]` extra (`src/burnt/databricks/`) is the workspace API client + system-table reader. It does NOT implement `PricingBackend`. Any existing `DatabricksPricingBackend` stub in core should be moved to `src/burnt/cloud/azure_databricks/__init__.py` as a stub with a `NotImplementedError` body.
+
+The `runtime/` auto-detect logic picks a backend based on what's installed and what credentials are present. When multiple backends are installed, the user selects via `burnt.toml` (`[burnt.pricing] backend = "azure-databricks"`).
+
+---
+
+## Acceptance Criteria
+
+- [ ] `src/burnt/core/pricing.py` exists and defines `PricingBackend` as a `Protocol` with `name: str` and `map(graph: CostGraph) -> CostEstimate`
+- [ ] `src/burnt/cloud/__init__.py` exists (may be empty)
+- [ ] `src/burnt/cloud/{azure_databricks,aws_databricks,gcp_databricks,onprem_spark}/__init__.py` exist (stubs)
+- [ ] No `PricingBackend` implementation lives in `src/burnt/core/` or `src/burnt/databricks/`
+- [ ] `from burnt.core.pricing import PricingBackend` works in a clean install
+- [ ] `uv run pytest -m unit -v` passes
+- [ ] `uv run ruff check src/` passes
+
+---
+
+## Verification
+
+### Commands
+
+```bash
+uv run python -c "from burnt.core.pricing import PricingBackend; print(PricingBackend)"
+uv run python -c "import burnt.cloud.azure_databricks; print('cloud stubs ok')"
+uv run pytest -m unit -v
+uv run ruff check src/ tests/
+```
+
+### Integration Check
+
+- [ ] `burnt check ./examples/notebook.py` still works end-to-end (pricing protocol addition is additive — no regressions)
+
+---
+
+## Handoff
+
+### Result
+
+[Executor fills this in when done.]
+
+```yaml
+status: todo
+```
+
+### Blocked reason
+
+Blocked by PN-01 (pyproject restructure) — extras must be in place before the cloud package dirs can be properly gated.

--- a/tasks/PN/03-notebook-extra-split.md
+++ b/tasks/PN/03-notebook-extra-split.md
@@ -1,0 +1,121 @@
+# Task: [notebook] extra split
+
+---
+
+## Metadata
+
+```yaml
+id: PN-03-notebook-extra-split
+status: todo
+phase: N
+priority: medium
+agent: ~
+blocked_by: [PN-01-pyproject-extras-restructure]
+created_by: planner
+```
+
+---
+
+## Context
+
+### Goal
+
+Gate HTML rendering behind the `[notebook]` extra and add a `.dbc` archive parser to that same extra. Today `display/notebook.py` is always installed and pulls in Jinja2 as an implicit dependency, which adds weight to the core install. Splitting it out preserves the "core install is small" promise: `pip install burnt` gives you 84 rules + compute-seconds via a Rich terminal table, nothing more.
+
+### Files to read
+
+```
+# Required
+src/burnt/display/notebook.py
+src/burnt/display/terminal.py
+src/burnt/__init__.py
+src/burnt/core/exceptions.py
+pyproject.toml
+
+# Reference
+docs/modular-architecture.md   §2.3
+DESIGN.md §9 Display
+```
+
+### Background
+
+**Graceful degradation contract:**
+
+- `result.to_html()` without `[notebook]` → raises `BurntError("'.to_html()' requires pip install burnt[notebook]")`
+- `result.display()` in a Jupyter environment without `[notebook]` → falls back to the terminal renderer (Rich → text) silently
+- `burnt check x.dbc` without `[notebook]` → exits 2 with `BurntError("'.dbc' archives require pip install burnt[notebook]")`
+- `.ipynb` parsing continues to work in the core install (no change)
+
+**DBC parser** (`src/burnt/parsers/dbc.py`):
+
+`.dbc` is a ZIP archive. Each notebook inside is a JSON file. Cell content can be plain UTF-8, Base64-encoded, or gzip-compressed + Base64. The parser extracts each cell's source and language, then routes it to the standard notebook parsing pipeline. No new dependencies: stdlib `zipfile`, `json`, `gzip`, `base64` only.
+
+```python
+# Rough shape
+def parse_dbc(path: str) -> list[NotebookCell]:
+    with zipfile.ZipFile(path) as zf:
+        for name in zf.namelist():
+            if name.endswith(".json"):
+                data = json.loads(zf.read(name))
+                for cell in data.get("commands", []):
+                    yield _decode_cell(cell)
+```
+
+**Import gating pattern** — follow the existing pattern in `src/burnt/runtime/__init__.py`:
+
+```python
+try:
+    from burnt.display._notebook_impl import NotebookRenderer
+except ImportError:
+    NotebookRenderer = None  # type: ignore[assignment,misc]
+```
+
+Then raise `BurntError` at call time if `NotebookRenderer is None`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `src/burnt/display/notebook.py` is gated: importing it without `jinja2` installed raises `ImportError`, not a syntax error
+- [ ] `result.to_html()` raises `BurntError` with a helpful message when `[notebook]` is not installed
+- [ ] `result.display()` in a Jupyter kernel falls back to terminal renderer (no exception) when `[notebook]` is not installed
+- [ ] `src/burnt/parsers/dbc.py` exists and handles plain UTF-8, Base64, and gzip+Base64 cell content
+- [ ] `burnt check notebook.dbc` works when `[notebook]` is installed; exits 2 with a clear message when it is not
+- [ ] Core install (`pip install burnt`) has no Jinja2 dependency
+- [ ] `uv run pytest -m unit -v` passes
+- [ ] `uv run ruff check src/` passes
+
+---
+
+## Verification
+
+### Commands
+
+```bash
+uv run pytest -m unit -v
+uv run ruff check src/ tests/
+# In a venv without [notebook]:
+python -c "from burnt.core.models import CheckResult; r = CheckResult.__new__(CheckResult); r.to_html()"
+# Should raise BurntError
+```
+
+### Integration Check
+
+- [ ] `pip install burnt` (no notebook extra) → `burnt check ./notebook.py` produces terminal output, no import errors
+- [ ] `pip install burnt[notebook]` → `result.to_html()` returns an HTML string
+
+---
+
+## Handoff
+
+### Result
+
+[Executor fills this in when done.]
+
+```yaml
+status: todo
+```
+
+### Blocked reason
+
+Blocked by PN-01 (the `[notebook]` extra must exist in pyproject.toml before this gating makes sense).

--- a/tasks/PN/04-cli-fix-diff-flags.md
+++ b/tasks/PN/04-cli-fix-diff-flags.md
@@ -1,0 +1,114 @@
+# Task: --fix, --unsafe-fixes, --diff CLI flags (core)
+
+---
+
+## Metadata
+
+```yaml
+id: PN-04-cli-fix-diff-flags
+status: todo
+phase: N
+priority: high
+agent: ~
+blocked_by: [PX-03-cli-rewire, PN-01-pyproject-extras-restructure]
+created_by: planner
+```
+
+---
+
+## Context
+
+### Goal
+
+Wire `--fix`, `--unsafe-fixes`, and `--diff <ref>` into `burnt check` as core CLI flags, no extra needed. These were previously discussed as `[fix]` and `[git]` extras but the April 2026 decision folded them into core — matching ruff's shape.
+
+### Files to read
+
+```
+# Required
+src/burnt/cli/main.py
+src/burnt/_check/__init__.py
+docs/writing-rules.md
+docs/modular-architecture.md   §2.1 (folded-in CLI flags)
+
+# Reference
+DESIGN.md §12 CLI
+```
+
+### Background
+
+**`--diff <ref>`**:
+- Run `git diff --name-only <ref>...HEAD` via `subprocess.run`
+- Filter the file list to only those burnt can parse (`.py`, `.sql`, `.ipynb`, `.dbc`)
+- Pass the filtered list to `_check.run()` instead of the path argument
+- No Python git library; no `[git]` extra
+- If `git` is not on PATH → exit 2 with a clear message
+
+**`--fix`**:
+- After `_check.run()` collects findings, apply autofixes for all findings where `rule.fix` is not None
+- Use LibCST to rewrite Python sources (LibCST is a core dep after PN-01)
+- Show a summary of applied fixes: `"Fixed 3 issues in 2 files"`
+- Rules declare autofixability via `[fix]` section in their TOML (see writing-rules.md)
+
+**`--unsafe-fixes`**:
+- Superset of `--fix` — also applies fixes marked `unsafe = true` in the rule TOML
+- These are fixes that may change observable semantics (e.g. reordering, removing a call)
+- Requires explicit opt-in; never applied automatically
+
+**Rule TOML `[fix]` section** (new, additive to existing format):
+```toml
+[fix]
+description = "Replace .collect() with .limit(n).collect()"
+unsafe = false   # true means --unsafe-fixes is required
+```
+
+Writing-rules.md needs a new section documenting this format.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `burnt check ./notebook.py --diff main` only lints files changed since `main` branch
+- [ ] `burnt check ./notebook.py --fix` applies all safe autofixes in-place and reports how many were applied
+- [ ] `burnt check ./notebook.py --unsafe-fixes` also applies unsafe fixes
+- [ ] `--diff` without git on PATH exits 2 with a message: `"'--diff' requires git to be installed and this directory to be a git repository"`
+- [ ] Autofixes use LibCST for Python rewrites (not regex or string replacement)
+- [ ] At least one existing rule has a `[fix]` section added to its TOML as a test case
+- [ ] `writing-rules.md` has a new section documenting the `[fix]` TOML format
+- [ ] `uv run pytest -m unit -v` passes (add unit tests for diff filtering and fix application)
+- [ ] `uv run ruff check src/` passes
+
+---
+
+## Verification
+
+### Commands
+
+```bash
+uv run pytest -m unit -v -k "fix or diff"
+uv run ruff check src/ tests/
+# Smoke test
+burnt check ./tests/fixtures/notebooks/ --diff HEAD~1
+burnt check ./tests/fixtures/notebooks/ --fix --dry-run   # if dry-run is implemented
+```
+
+### Integration Check
+
+- [ ] `burnt check ./notebook.py --diff HEAD` runs without error in a git repo
+- [ ] `burnt check ./notebook.py --fix` modifies a test fixture that has a known-fixable rule violation
+
+---
+
+## Handoff
+
+### Result
+
+[Executor fills this in when done.]
+
+```yaml
+status: todo
+```
+
+### Blocked reason
+
+Blocked by PX-03 (CLI must be rewired to `_check.run()` before flags can be added) and PN-01 (`libcst` must be a core dep).

--- a/tasks/PN/05-config-schema-additions.md
+++ b/tasks/PN/05-config-schema-additions.md
@@ -1,0 +1,148 @@
+# Task: Config schema additions — pricing backend + system-table paths
+
+---
+
+## Metadata
+
+```yaml
+id: PN-05-config-schema-additions
+status: todo
+phase: N
+priority: high
+agent: ~
+blocked_by: [PN-01-pyproject-extras-restructure, PN-02-pricing-backend-protocol]
+created_by: planner
+```
+
+---
+
+## Context
+
+### Goal
+
+Add two new configuration sections to the `burnt.toml` / `[tool.burnt]` schema:
+
+1. **`[burnt.pricing]`** — backend selection when multiple pricing extras are installed
+2. **`[burnt.databricks.system_tables]`** — configurable system-table paths for orgs that mirror system tables into private schemas
+
+Also add **`[burnt.onprem_spark]`** — per-unit cost rates for the `[onprem-spark]` pricing backend.
+
+These are additive config changes: existing configs are unaffected; new keys are ignored when the relevant extra is not installed.
+
+### Files to read
+
+```
+# Required
+src/burnt/_config/
+docs/configuration.md
+docs/modular-architecture.md   §3, §3.5
+pyproject.toml
+
+# Reference
+DESIGN.md §11 Configuration
+src/burnt/core/exceptions.py
+```
+
+### Background
+
+**`[burnt.pricing]`** (from modular-architecture.md §3):
+
+```toml
+[burnt.pricing]
+backend = "azure-databricks"   # which PricingBackend to use when multiple extras installed
+                               # options: "azure-databricks", "aws-databricks", "gcp-databricks",
+                               #          "onprem-spark"
+                               # default: auto (uses whichever single backend is installed;
+                               #          errors if multiple installed and none configured)
+```
+
+Env-var override: `BURNT_PRICING_BACKEND`.
+
+**`[burnt.databricks.system_tables]`** (exact keys from modular-architecture.md §3.5):
+
+```toml
+[burnt.databricks.system_tables]
+query_history             = "system.query.history"
+billing_usage             = "system.billing.usage"
+list_prices               = "system.billing.list_prices"
+information_schema_tables = "system.information_schema.tables"
+compute_clusters          = "system.compute.clusters"
+node_timeline             = "system.compute.node_timeline"
+enabled                   = true   # master switch; false = never query system tables
+```
+
+Env-var overrides: `BURNT_DATABRICKS_SYSTEM_TABLES_QUERY_HISTORY`, etc.
+
+Behaviour rules (must be implemented):
+1. If a configured table is unreadable, log once at INFO and fall back silently (never error)
+2. Paths resolved once per `burnt.check()` call, cached on result
+3. `burnt doctor` reports which system tables are reachable
+
+**`[burnt.onprem_spark]`**:
+
+```toml
+[burnt.onprem_spark]
+cost_per_vcpu_hour   = 0.048   # $/vCPU-hour (required when [onprem-spark] is the backend)
+cost_per_gb_hour     = 0.006   # $/GB-hour memory
+cost_per_gb_shuffle  = 0.001   # $/GB shuffled
+```
+
+Env-var overrides: `BURNT_ONPREM_SPARK_COST_PER_VCPU_HOUR`, etc.
+
+Use the existing Pydantic Settings models in `src/burnt/_config/` — extend them, don't replace them. Follow the same pattern as the existing `LintSettings` and `CacheSettings` classes.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `BurntConfig` (or equivalent Pydantic settings model) has a `pricing` sub-model with `backend: str | None = None`
+- [ ] `BurntConfig` has a `databricks.system_tables` sub-model with the 6 path fields and `enabled: bool = True`
+- [ ] `BurntConfig` has an `onprem_spark` sub-model with the 3 cost rate fields
+- [ ] All new fields are readable from `burnt.toml`, `[tool.burnt]` in `pyproject.toml`, and env vars
+- [ ] Invalid `backend` value (not one of the four named backends) raises `ConfigError` with a helpful message listing valid options
+- [ ] `burnt doctor` output includes a "System tables" section reporting reachability for each configured path (when `[databricks]` is installed)
+- [ ] `burnt init` config generator includes the new sections as commented-out examples
+- [ ] `docs/configuration.md` updated with the new sections (this is the main user-facing doc)
+- [ ] `uv run pytest -m unit -v` passes (add unit tests for config loading and validation)
+- [ ] `uv run ruff check src/` passes
+
+---
+
+## Verification
+
+### Commands
+
+```bash
+uv run pytest -m unit -v -k "config or settings or system_tables or pricing"
+uv run ruff check src/ tests/
+# Config loading smoke test
+python -c "
+from burnt._config import load_config
+import os
+os.environ['BURNT_PRICING_BACKEND'] = 'azure-databricks'
+cfg = load_config()
+assert cfg.pricing.backend == 'azure-databricks'
+print('config ok')
+"
+```
+
+### Integration Check
+
+- [ ] A `burnt.toml` with `[burnt.databricks.system_tables] enabled = false` causes `burnt doctor` to report system tables as disabled
+- [ ] A `burnt.toml` with `[burnt.pricing] backend = "onprem-spark"` causes `result.cost_estimate.backend == "onprem-spark"` (once PN-02 is implemented)
+
+---
+
+## Handoff
+
+### Result
+
+[Executor fills this in when done.]
+
+```yaml
+status: todo
+```
+
+### Blocked reason
+
+Blocked by PN-01 (extras must exist for the backend validation list to be authoritative) and PN-02 (PricingBackend protocol must exist before backend selection logic makes sense).

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -10,6 +10,7 @@ This directory is the **handoff protocol** between the Planner agent and the Exe
 Phase 0: Base Rework ──────────────── Cleanup, new architecture setup [done]
 Phase 1: Rust Engine ──────────────── tree-sitter, CostGraph, 84 rules [done]
 Phase X: Design Alignment ─────────── Dead code removal, docs, sparkMeasure session [in-progress]
+Phase N: Modular Architecture ─────── Pricing backends, [notebook] extra, pyproject restructure [todo]
 Phase 2: Session & Intelligence ───── Cost estimation, EXPLAIN enrichment [todo, unblocked after PX]
 Phase 3: CLI Completion ───────────── Rewire check, SARIF output, event log [todo]
 Phase 4: Databricks Module ────────── DatabricksBackend, dollar estimates, Delta enrichment [todo]
@@ -18,10 +19,10 @@ Phase 6: Validation ───────────────── Dogfood,
 ```
 
 > **Strategic Position (April 2026):**
-> - **Databricks-first** — lint rules work without credentials; cost intelligence requires Databricks
+> - **Spark-generic** — 84 lint rules + CostGraph work on any Spark code (EMR, Glue, Dataproc, on-prem, Databricks); cost-in-dollars requires a pricing-backend extra
 > - **CLI-first** — `burnt check` is the product; notebook API is a second mode
-> - **Full notebook hygiene** — cost + style + structure rules ("ruff for Databricks notebooks")
-> - **sparkMeasure** replaces the broken SparkListener/statusTracker session implementation
+> - **Full notebook hygiene** — cost + style + structure rules ("ruff for Databricks notebooks, and beyond")
+> - **sparkMeasure is core** — runtime metric capture ships with `pip install burnt`; no extra needed
 
 ---
 
@@ -35,6 +36,18 @@ Phase 6: Validation ───────────────── Dogfood,
 | `PX/04-sarif-output` | todo | Add SARIF 2.1.0 output format for GitHub Code Scanning |
 | `PX/05-design-doc-update` | done | Update DESIGN.md, AGENTS.md, README.md, pyproject.toml |
 | `PX/06-tasks-cleanup` | done | Archive old P4 tasks, rewrite thin tasks, update this README |
+
+---
+
+## Phase N: Modular Architecture *(acts on the April 2026 re-statement in `docs/modular-architecture.md`)*
+
+| Task | Status | What |
+|------|--------|------|
+| `PN/01-pyproject-extras-restructure` | todo | Remove `[sql]`,`[spark]`,`[alerts]`; add `sparkmeasure`+`libcst` to core; add `[notebook]`,`[azure-databricks]`,`[aws-databricks]`,`[gcp-databricks]`,`[onprem-spark]` |
+| `PN/02-pricing-backend-protocol` | todo | Create `PricingBackend` protocol in `src/burnt/core/pricing.py`; stub `src/burnt/cloud/` dirs; migrate `DatabricksPricingBackend` out of core |
+| `PN/03-notebook-extra-split` | todo | Gate `display/notebook.py` behind `[notebook]`; add `parsers/dbc.py`; core stub raises `NotAvailableError` |
+| `PN/04-cli-fix-diff-flags` | todo | Add `--fix`, `--unsafe-fixes`, `--diff <ref>` to `burnt check` (core, no extra needed) |
+| `PN/05-config-schema-additions` | todo | Add `[burnt.databricks.system_tables]` paths + `[burnt.pricing] backend` selection to config schema |
 
 ---
 
@@ -103,11 +116,11 @@ Phase 6: Validation ───────────────── Dogfood,
 | `P3/07-graceful-degradation` | done | Static-only when Spark/Databricks unavailable |
 | `P3/08-performance-tuning` | todo | Benchmark script, latency and memory targets |
 
-## Phase 4: Databricks Module
+## Phase 4: Databricks Backend *(scope: Databricks-specific extras, after Phase N)*
 
 | Task | Status | What |
 |------|--------|-------|
-| `P4/01-databricks-namespace` | todo | Consolidate Databricks code under `burnt/databricks/` |
+| `P4/01-databricks-namespace` | todo | Consolidate Databricks code under `burnt/databricks/` (workspace API + system-table reader, no pricing data) |
 | `P4/02-rest-backend-move` | todo | Move RestBackend to `burnt/databricks/runtime/` |
 | `P4/03-databricks-cli` | todo | Databricks-specific CLI commands |
 | `P4/06-delta-enrichment` | todo | DESCRIBE DETAIL via DatabricksBackend |


### PR DESCRIPTION
Ground the package in its Spark-generic identity across all surfaces:

- README.md: new tagline ("Cost Compiler for Spark"), install matrix with
  all pricing-backend extras, honest v0.2.0-dev status callout, updated
  architecture diagram showing PricingBackend layer
- DESIGN.md: §1 product → Spark pipelines, §2 philosophy → Spark-generic,
  §4 backend → PricingBackend protocol, §10 renamed "Pricing Backends" with
  [databricks]/[*-databricks]/[onprem-spark] breakdown, §11 config adds
  [burnt.pricing], [burnt.onprem_spark], [burnt.databricks.system_tables],
  §14 stack → sparkmeasure + libcst as core deps, §15 structure → cloud/ dir,
  §18 phases → adds Phase N
- docs/configuration.md: new sections for pricing backend selection,
  on-prem rates, and Databricks system-table path overrides
- docs/modular-architecture.md: decision-status header added so future
  sessions know what has been actioned
- tasks/README.md: strategic position → Spark-generic, Phase N added to
  roadmap and table, Phase 4 renamed "Databricks Backend"
- tasks/PN/: five new task files (pyproject restructure, PricingBackend
  protocol, [notebook] extra split, --fix/--diff flags, config schema)
- pyproject.toml: description updated to "Cost Compiler for Spark"

https://claude.ai/code/session_01Wjm77ad5yFDd6eQHc6t1se