### PR TITLE
feat: add 66 new PySpark/Databricks lint rules (Phases 1–4)

### DIFF
--- a/src/burnt-engine/rules/config/BC001_legacy_sql_flag.toml
+++ b/src/burnt-engine/rules/config/BC001_legacy_sql_flag.toml
@@ -1,0 +1,35 @@
+[rule]
+id = "legacy_sql_flag"
+code = "BC001"
+severity = "warning"
+language = "python"
+description = "spark.sql.legacy.* flag papers over real compatibility bugs instead of fixing them"
+suggestion = "Remove the legacy flag and migrate the code to Spark 3.x behavior"
+category = "Config"
+tags = ["pyspark", "sql", "correctness", "config"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (identifier)
+      attribute: (identifier) @conf)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (string) @key
+    (_))
+  (#eq? @conf "conf")
+  (#eq? @method "set")
+  (#match? @key "spark\\.sql\\.legacy\\."))
+"""
+
+[tests]
+pass = [
+    "spark.conf.set(\"spark.sql.adaptive.enabled\", \"true\")",
+]
+fail = [
+    "spark.conf.set(\"spark.sql.legacy.timeParserPolicy\", \"LEGACY\")",
+    "spark.conf.set(\"spark.sql.legacy.parquet.datetimeRebaseModeInRead\", \"LEGACY\")",
+]

--- a/src/burnt-engine/rules/config/BC002_retention_check_disabled.toml
+++ b/src/burnt-engine/rules/config/BC002_retention_check_disabled.toml
@@ -1,0 +1,35 @@
+[rule]
+id = "retention_check_disabled"
+code = "BC002"
+severity = "error"
+language = "python"
+description = "Bypassing the 7-day VACUUM retention safety check has caused production data loss"
+suggestion = "Remove this config; use VACUUM RETAIN <hours> HOURS instead of disabling the check"
+category = "Config"
+tags = ["delta", "correctness", "config"]
+platform = "databricks"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (identifier)
+      attribute: (identifier) @conf)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (string) @key
+    (string) @val)
+  (#eq? @conf "conf")
+  (#eq? @method "set")
+  (#match? @key "retentionDurationCheck\\.enabled")
+  (#match? @val "false"))
+"""
+
+[tests]
+pass = [
+    "spark.conf.set(\"spark.databricks.delta.retentionDurationCheck.enabled\", \"true\")",
+]
+fail = [
+    "spark.conf.set(\"spark.databricks.delta.retentionDurationCheck.enabled\", \"false\")",
+]

--- a/src/burnt-engine/rules/config/BC003_auto_merge_schema_global.toml
+++ b/src/burnt-engine/rules/config/BC003_auto_merge_schema_global.toml
@@ -1,0 +1,35 @@
+[rule]
+id = "auto_merge_schema_global"
+code = "BC003"
+severity = "warning"
+language = "python"
+description = "Enabling Delta schema auto-merge at session scope is not recommended for production; use per-write mergeSchema instead"
+suggestion = "Replace with .option(\"mergeSchema\", \"true\") on individual writes"
+category = "Config"
+tags = ["delta", "correctness", "config"]
+platform = "databricks"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (identifier)
+      attribute: (identifier) @conf)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (string) @key
+    (string) @val)
+  (#eq? @conf "conf")
+  (#eq? @method "set")
+  (#match? @key "schema\\.autoMerge\\.enabled")
+  (#match? @val "true"))
+"""
+
+[tests]
+pass = [
+    "df.write.option(\"mergeSchema\", \"true\").format(\"delta\").save(path)",
+]
+fail = [
+    "spark.conf.set(\"spark.databricks.delta.schema.autoMerge.enabled\", \"true\")",
+]

--- a/src/burnt-engine/rules/config/BC005_optimize_write_disabled.toml
+++ b/src/burnt-engine/rules/config/BC005_optimize_write_disabled.toml
@@ -1,0 +1,35 @@
+[rule]
+id = "optimize_write_disabled"
+code = "BC005"
+severity = "warning"
+language = "python"
+description = "Disabling optimizeWrite causes small-file proliferation on high-churn Delta tables"
+suggestion = "Remove this config or set it to true"
+category = "Config"
+tags = ["delta", "performance", "config"]
+platform = "databricks"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (identifier)
+      attribute: (identifier) @conf)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (string) @key
+    (string) @val)
+  (#eq? @conf "conf")
+  (#eq? @method "set")
+  (#match? @key "optimizeWrite\\.enabled")
+  (#match? @val "false"))
+"""
+
+[tests]
+pass = [
+    "spark.conf.set(\"spark.databricks.delta.optimizeWrite.enabled\", \"true\")",
+]
+fail = [
+    "spark.conf.set(\"spark.databricks.delta.optimizeWrite.enabled\", \"false\")",
+]

--- a/src/burnt-engine/rules/config/BC006_merge_low_shuffle_disabled.toml
+++ b/src/burnt-engine/rules/config/BC006_merge_low_shuffle_disabled.toml
@@ -1,0 +1,35 @@
+[rule]
+id = "merge_low_shuffle_disabled"
+code = "BC006"
+severity = "info"
+language = "python"
+description = "Disabling Delta low-shuffle merge causes unnecessary full shuffle on MERGE operations"
+suggestion = "Remove this config or set it to true"
+category = "Config"
+tags = ["delta", "performance", "config"]
+platform = "databricks"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (identifier)
+      attribute: (identifier) @conf)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (string) @key
+    (string) @val)
+  (#eq? @conf "conf")
+  (#eq? @method "set")
+  (#match? @key "enableLowShuffle")
+  (#match? @val "false"))
+"""
+
+[tests]
+pass = [
+    "spark.conf.set(\"spark.databricks.delta.merge.enableLowShuffle\", \"true\")",
+]
+fail = [
+    "spark.conf.set(\"spark.databricks.delta.merge.enableLowShuffle\", \"false\")",
+]

--- a/src/burnt-engine/rules/delta/BD001_delta_vacuum_too_frequent.toml
+++ b/src/burnt-engine/rules/delta/BD001_delta_vacuum_too_frequent.toml
@@ -7,6 +7,7 @@ description = "VACUUM called more frequently than needed"
 suggestion = "Adjust vacuum retention based on table size and update frequency"
 category = "Delta"
 tags = ["delta", "maintenance", "sql"]
+platform = "delta"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/delta/BD002_missing_zorder.toml
+++ b/src/burnt-engine/rules/delta/BD002_missing_zorder.toml
@@ -7,6 +7,7 @@ description = "Large Delta table missing ZORDER optimization"
 suggestion = "Add ZORDER BY on frequently filtered columns"
 category = "Delta"
 tags = ["delta", "performance", "sql"]
+platform = "delta"
 
 [context]
 type = "missing_zorder"

--- a/src/burnt-engine/rules/delta/BD010_overwrite_without_replace_where.toml
+++ b/src/burnt-engine/rules/delta/BD010_overwrite_without_replace_where.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "overwrite_without_replace_where"
+code = "BD010"
+severity = "warning"
+language = "python"
+description = "mode('overwrite') on a Delta table replaces the entire table — use replaceWhere to scope the overwrite to a partition"
+suggestion = "Replace .mode('overwrite') with .option('replaceWhere', 'partition_col = value') for partition-level writes"
+category = "BestPractice"
+tags = ["pyspark", "delta", "write", "performance"]
+platform = "delta"
+
+[context]
+type = "overwrite_without_replace_where"
+
+[tests]
+pass = [
+    "df.write.format('delta').option('replaceWhere', \"date='2024-01'\").mode('overwrite').save(path)",
+    "df.write.format('delta').mode('append').save(path)",
+]
+fail = [
+    "df.write.format('delta').mode('overwrite').save(path)",
+    "df.write.format('delta').mode('overwrite').saveAsTable('events')",
+]

--- a/src/burnt-engine/rules/delta/BD013_csv_json_analytical_write.toml
+++ b/src/burnt-engine/rules/delta/BD013_csv_json_analytical_write.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "csv_json_analytical_write"
+code = "BD013"
+severity = "warning"
+language = "python"
+description = "Writing analytical tables as CSV or JSON lacks schema enforcement, ACID transactions, and time travel"
+suggestion = "Use .format('delta') for analytical tables; reserve CSV/JSON for landing zones or exports"
+category = "BestPractice"
+tags = ["pyspark", "delta", "write"]
+platform = "all"
+
+[context]
+type = "csv_json_analytical_write"
+
+[tests]
+pass = [
+    "df.write.format('delta').save('/data/output')",
+    "df.write.format('csv').save('/data/landing')",
+]
+fail = [
+    "df.write.format('csv').save('/data/analytics/events')",
+    "df.write.format('json').saveAsTable('processed_events')",
+]

--- a/src/burnt-engine/rules/delta/BD014_parquet_write_databricks.toml
+++ b/src/burnt-engine/rules/delta/BD014_parquet_write_databricks.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "parquet_write_databricks"
+code = "BD014"
+severity = "info"
+language = "python"
+description = "Writing as Parquet on Databricks foregoes Delta Lake ACID transactions, schema enforcement, and time travel"
+suggestion = "Use .format('delta') instead of .format('parquet') for analytical tables on Databricks"
+category = "BestPractice"
+tags = ["pyspark", "delta", "write", "databricks"]
+platform = "databricks"
+
+[context]
+type = "parquet_write_databricks"
+
+[tests]
+pass = [
+    "df.write.format('delta').save(path)",
+    "df.write.format('orc').save(path)",
+]
+fail = [
+    "df.write.format('parquet').save(path)",
+    "df.write.format('parquet').saveAsTable('events')",
+]

--- a/src/burnt-engine/rules/delta/BD015_save_as_table_no_format.toml
+++ b/src/burnt-engine/rules/delta/BD015_save_as_table_no_format.toml
@@ -1,0 +1,29 @@
+[rule]
+id = "save_as_table_no_format"
+code = "BD015"
+severity = "warning"
+language = "python"
+description = "saveAsTable() without an explicit .format('delta') may write in the default Hive format on some clusters"
+suggestion = "Chain .format('delta').saveAsTable(...) to guarantee a Delta table is written"
+category = "BestPractice"
+tags = ["pyspark", "delta", "write"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @method)
+  (#eq? @method "saveAsTable"))
+"""
+
+[tests]
+pass = [
+    "df.write.format('delta').save('/path/to/data')",
+    "df.write.format('parquet').save('/path')",
+]
+fail = [
+    "df.write.saveAsTable('mydb.mytable')",
+    "df.write.mode('overwrite').saveAsTable('events')",
+]

--- a/src/burnt-engine/rules/delta/BD016_write_in_loop.toml
+++ b/src/burnt-engine/rules/delta/BD016_write_in_loop.toml
@@ -1,0 +1,44 @@
+[rule]
+id = "write_in_loop"
+code = "BD016"
+severity = "warning"
+language = "python"
+description = ".write inside a loop creates one small file per iteration and bypasses Delta's optimized bulk-write path"
+suggestion = "Collect data into a single DataFrame and call .write once, or use foreachBatch with Delta merge"
+category = "BestPractice"
+tags = ["pyspark", "delta", "loop", "performance"]
+platform = "all"
+
+[query]
+detect = """
+(for_statement
+  body: (block
+    (expression_statement
+      (call
+        function: (attribute
+          object: (attribute
+            object: (_)
+            attribute: (identifier) @write)
+          attribute: (_))
+        (#eq? @write "write")))))
+
+(for_statement
+  body: (block
+    (expression_statement
+      (assignment
+        right: (call
+          function: (attribute
+            object: (attribute
+              object: (_)
+              attribute: (identifier) @write2)
+            attribute: (_))
+          (#eq? @write2 "write"))))))
+"""
+
+[tests]
+pass = [
+    "df.write.format('delta').save('/data/output')",
+]
+fail = [
+    "for date in dates:\n    df.write.save(f'/data/{date}')",
+]

--- a/src/burnt-engine/rules/delta/BD020_optimize_without_where.toml
+++ b/src/burnt-engine/rules/delta/BD020_optimize_without_where.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "optimize_without_where"
+code = "BD020"
+severity = "info"
+language = "sql"
+description = "OPTIMIZE without a WHERE clause rewrites the entire table — expensive on large tables"
+suggestion = "Add a WHERE clause on a partition column to scope the optimization to recent data only"
+category = "BestPractice"
+tags = ["delta", "performance", "sql"]
+platform = "delta"
+
+[context]
+type = "optimize_without_where"
+
+[tests]
+pass = [
+    "OPTIMIZE events WHERE date >= '2024-01-01'",
+    "OPTIMIZE catalog.schema.table WHERE partition_col = '2024-01'",
+]
+fail = [
+    "OPTIMIZE events",
+    "OPTIMIZE catalog.schema.large_table",
+]

--- a/src/burnt-engine/rules/delta/BD021_merge_without_partition_predicate.toml
+++ b/src/burnt-engine/rules/delta/BD021_merge_without_partition_predicate.toml
@@ -1,0 +1,21 @@
+[rule]
+id = "merge_without_partition_predicate"
+code = "BD021"
+severity = "warning"
+language = "sql"
+description = "MERGE INTO without a partition column in the ON condition causes a full table scan on every merge"
+suggestion = "Add a partition predicate to the ON clause: ON target.partition_col = source.partition_col AND target.id = source.id"
+category = "BestPractice"
+tags = ["delta", "performance", "sql"]
+platform = "delta"
+
+[context]
+type = "merge_without_partition_predicate"
+
+[tests]
+pass = [
+    "MERGE INTO target USING source ON target.date = source.date AND target.id = source.id WHEN MATCHED THEN UPDATE SET *",
+]
+fail = [
+    "MERGE INTO events USING updates ON events.id = updates.id WHEN MATCHED THEN UPDATE SET *",
+]

--- a/src/burnt-engine/rules/delta/BD022_merge_update_star_no_filter.toml
+++ b/src/burnt-engine/rules/delta/BD022_merge_update_star_no_filter.toml
@@ -1,0 +1,21 @@
+[rule]
+id = "merge_update_star_no_filter"
+code = "BD022"
+severity = "info"
+language = "sql"
+description = "WHEN MATCHED THEN UPDATE SET * without an AND condition updates unchanged rows, causing unnecessary rewrites"
+suggestion = "Add a change-detection condition: WHEN MATCHED AND source.updated_at > target.updated_at THEN UPDATE SET *"
+category = "BestPractice"
+tags = ["delta", "performance", "sql"]
+platform = "delta"
+
+[context]
+type = "merge_update_star_no_filter"
+
+[tests]
+pass = [
+    "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED AND s.ts > t.ts THEN UPDATE SET * WHEN NOT MATCHED THEN INSERT *",
+]
+fail = [
+    "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET * WHEN NOT MATCHED THEN INSERT *",
+]

--- a/src/burnt-engine/rules/delta/BD026_convert_to_delta_no_optimize.toml
+++ b/src/burnt-engine/rules/delta/BD026_convert_to_delta_no_optimize.toml
@@ -1,0 +1,21 @@
+[rule]
+id = "convert_to_delta_no_optimize"
+code = "BD026"
+severity = "info"
+language = "sql"
+description = "CONVERT TO DELTA leaves small files from the source format — run OPTIMIZE afterward"
+suggestion = "Follow CONVERT TO DELTA with OPTIMIZE <table> to compact the converted files"
+category = "BestPractice"
+tags = ["delta", "performance", "sql"]
+platform = "delta"
+
+[context]
+type = "convert_to_delta_no_optimize"
+
+[tests]
+pass = [
+    "CONVERT TO DELTA parquet.`/path/to/data`;\nOPTIMIZE my_table",
+]
+fail = [
+    "CONVERT TO DELTA parquet.`/path/to/data`",
+]

--- a/src/burnt-engine/rules/delta/BD032_too_many_cluster_keys.toml
+++ b/src/burnt-engine/rules/delta/BD032_too_many_cluster_keys.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "too_many_cluster_keys"
+code = "BD032"
+severity = "warning"
+language = "sql"
+description = "More than 4 Liquid Clustering keys reduces clustering effectiveness and increases write overhead"
+suggestion = "Limit CLUSTER BY to the 2-4 most-queried columns; additional columns provide diminishing returns"
+category = "BestPractice"
+tags = ["delta", "performance", "sql"]
+platform = "databricks"
+
+[context]
+type = "too_many_cluster_keys"
+
+[tests]
+pass = [
+    "CREATE TABLE t (a INT, b STRING) CLUSTER BY (a, b)",
+    "CREATE TABLE t (a INT) CLUSTER BY (a, b, c, d)",
+]
+fail = [
+    "CREATE TABLE t (a INT) CLUSTER BY (a, b, c, d, e)",
+    "CREATE TABLE t (a INT) CLUSTER BY (col1, col2, col3, col4, col5, col6)",
+]

--- a/src/burnt-engine/rules/governance/BU001_two_part_table_name.toml
+++ b/src/burnt-engine/rules/governance/BU001_two_part_table_name.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "two_part_table_name"
+code = "BU001"
+severity = "warning"
+language = "sql"
+description = "Two-part table name (schema.table) omits the Unity Catalog catalog prefix and resolves to the default catalog"
+suggestion = "Use three-part naming: catalog.schema.table to make catalog resolution explicit and portable"
+category = "Governance"
+tags = ["unity-catalog", "governance", "sql"]
+platform = "databricks"
+
+[context]
+type = "two_part_table_name"
+
+[tests]
+pass = [
+    "SELECT * FROM my_catalog.my_schema.my_table",
+    "SELECT * FROM catalog.schema.table",
+]
+fail = [
+    "SELECT * FROM my_schema.my_table",
+    "SELECT * FROM default.events WHERE date > '2024-01-01'",
+]

--- a/src/burnt-engine/rules/governance/BU002_hive_metastore_reference.toml
+++ b/src/burnt-engine/rules/governance/BU002_hive_metastore_reference.toml
@@ -1,0 +1,25 @@
+[rule]
+id = "hive_metastore_reference"
+code = "BU002"
+severity = "warning"
+language = "python"
+description = "hive_metastore references in new code prevent migration to Unity Catalog and break cross-workspace portability"
+suggestion = "Replace hive_metastore with a Unity Catalog three-part name: catalog.schema.table"
+category = "Governance"
+tags = ["unity-catalog", "governance", "delta"]
+platform = "databricks"
+
+[query]
+detect = """
+((string) @s
+ (#match? @s "hive_metastore"))
+"""
+
+[tests]
+pass = [
+    "spark.read.table(\"my_catalog.my_schema.my_table\")",
+]
+fail = [
+    "spark.read.table(\"hive_metastore.default.orders\")",
+    "df.write.saveAsTable(\"hive_metastore.analytics.results\")",
+]

--- a/src/burnt-engine/rules/governance/BU003_hardcoded_storage_path.toml
+++ b/src/burnt-engine/rules/governance/BU003_hardcoded_storage_path.toml
@@ -1,0 +1,27 @@
+[rule]
+id = "hardcoded_storage_path"
+code = "BU003"
+severity = "error"
+language = "python"
+description = "Hardcoded DBFS or cloud storage paths are deprecated on Databricks — both DBFS root and mounts are being phased out"
+suggestion = "Use Unity Catalog Volumes: /Volumes/<catalog>/<schema>/<volume>/..."
+category = "Governance"
+tags = ["unity-catalog", "governance", "security"]
+platform = "databricks"
+
+[query]
+detect = """
+((string) @s
+ (#match? @s "(dbfs:/(mnt|FileStore)|s3a?://|abfss://|gs://|wasbs?://)"))
+"""
+
+[tests]
+pass = [
+    "path = '/Volumes/my_catalog/my_schema/my_volume/data'",
+    "path = 'relative/path/to/data'",
+]
+fail = [
+    "path = 'dbfs:/mnt/mydata/file.csv'",
+    "path = 's3://my-bucket/prefix/data.parquet'",
+    "path = 'abfss://container@account.dfs.core.windows.net/path'",
+]

--- a/src/burnt-engine/rules/governance/BU004_dbutils_mount.toml
+++ b/src/burnt-engine/rules/governance/BU004_dbutils_mount.toml
@@ -1,0 +1,31 @@
+[rule]
+id = "dbutils_mount"
+code = "BU004"
+severity = "error"
+language = "python"
+description = "dbutils.fs.mount() creates DBFS mounts which are deprecated in Unity Catalog workspaces"
+suggestion = "Use Unity Catalog external locations or Volumes instead of DBFS mounts"
+category = "Governance"
+tags = ["unity-catalog", "governance", "security"]
+platform = "databricks"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (identifier) @db
+      attribute: (identifier) @fs)
+    attribute: (identifier) @method)
+  (#eq? @db "dbutils")
+  (#eq? @fs "fs")
+  (#eq? @method "mount"))
+"""
+
+[tests]
+pass = [
+    "dbutils.fs.ls('/Volumes/catalog/schema/vol/')",
+]
+fail = [
+    "dbutils.fs.mount('s3://my-bucket', '/mnt/mydata')",
+]

--- a/src/burnt-engine/rules/join/BJ002_self_join_no_alias.toml
+++ b/src/burnt-engine/rules/join/BJ002_self_join_no_alias.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "self_join_no_alias"
+code = "BJ002"
+severity = "warning"
+language = "python"
+description = "Self-joining a DataFrame without aliasing produces ambiguous column references that cause AnalysisException"
+suggestion = "Alias both sides before joining: left = df.alias('left'); right = df.alias('right'); left.join(right, ...)"
+category = "BestPractice"
+tags = ["pyspark", "join", "correctness"]
+platform = "all"
+
+[context]
+type = "self_join_no_alias"
+
+[tests]
+pass = [
+    "left = df.alias('left')\nright = df.alias('right')\nleft.join(right, left.id == right.parent_id)",
+    "df.join(other, 'id')",
+]
+fail = [
+    "df.join(df, df.parent_id == df.id)",
+    "employees.join(employees, employees.manager_id == employees.id)",
+]

--- a/src/burnt-engine/rules/join/BJ004_join_string_condition.toml
+++ b/src/burnt-engine/rules/join/BJ004_join_string_condition.toml
@@ -1,0 +1,32 @@
+[rule]
+id = "join_string_condition"
+code = "BJ004"
+severity = "warning"
+language = "python"
+description = "Passing a column name as a string to .join() produces an ambiguous column reference when both DataFrames have that column"
+suggestion = "Use col('left_df.col') == col('right_df.col') or join on a list of column names for unambiguous column resolution"
+category = "BestPractice"
+tags = ["pyspark", "join", "correctness"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    . (_) .
+    (string) @cond)
+  (#eq? @method "join"))
+"""
+
+[tests]
+pass = [
+    "df.join(other, col('df.id') == col('other.id'), 'left')",
+    "df.join(other, ['id', 'date'], 'inner')",
+]
+fail = [
+    "df.join(other, 'user_id')",
+    "df.join(lookup, 'id', 'left')",
+]

--- a/src/burnt-engine/rules/notebook/BB001_cluster_tag_missing.toml
+++ b/src/burnt-engine/rules/notebook/BB001_cluster_tag_missing.toml
@@ -7,6 +7,7 @@ description = "Cluster tag missing from notebook configuration"
 suggestion = "Add cluster tags for cost attribution"
 category = "Notebook"
 tags = ["notebook", "cost", "governance"]
+platform = "databricks"
 
 [context]
 type = "cluster_tag"

--- a/src/burnt-engine/rules/notebook/BN001_missing_run_target.toml
+++ b/src/burnt-engine/rules/notebook/BN001_missing_run_target.toml
@@ -7,6 +7,7 @@ description = "Notebook missing run directive or target"
 suggestion = "Add a run directive or specify a target"
 category = "Notebook"
 tags = ["notebook", "structure"]
+platform = "databricks"
 
 [context]
 type = "missing_run_target"

--- a/src/burnt-engine/rules/notebook/BN002_dynamic_sql.toml
+++ b/src/burnt-engine/rules/notebook/BN002_dynamic_sql.toml
@@ -7,6 +7,7 @@ description = "Dynamic SQL construction detected - potential SQL injection risk"
 suggestion = "Use parameterized queries instead of string concatenation"
 category = "Notebook"
 tags = ["notebook", "security", "sql"]
+platform = "databricks"
 
 [context]
 type = "dynamic_sql"

--- a/src/burnt-engine/rules/notebook/BN003_circular_run.toml
+++ b/src/burnt-engine/rules/notebook/BN003_circular_run.toml
@@ -7,6 +7,7 @@ description = "Circular run directive detected - notebook would call itself"
 suggestion = "Remove the circular reference"
 category = "Notebook"
 tags = ["notebook", "structure", "correctness"]
+platform = "databricks"
 
 [context]
 type = "circular_run"

--- a/src/burnt-engine/rules/notebook/BP005_missing_cell_type.toml
+++ b/src/burnt-engine/rules/notebook/BP005_missing_cell_type.toml
@@ -7,6 +7,7 @@ description = "Cell missing type declaration"
 suggestion = "Add cell type (python, sql, or markdown)"
 category = "Notebook"
 tags = ["notebook", "style", "structure"]
+platform = "databricks"
 
 [context]
 type = "missing_cell_type"

--- a/src/burnt-engine/rules/notebook/BP006_large_notebook.toml
+++ b/src/burnt-engine/rules/notebook/BP006_large_notebook.toml
@@ -7,6 +7,7 @@ description = "Large notebook detected (>50 cells) - consider splitting"
 suggestion = "Split into multiple notebooks for better maintainability"
 category = "Notebook"
 tags = ["notebook", "structure", "maintainability"]
+platform = "all"
 
 [context]
 type = "large_notebook"

--- a/src/burnt-engine/rules/notebook/BP007_no_markdown.toml
+++ b/src/burnt-engine/rules/notebook/BP007_no_markdown.toml
@@ -7,6 +7,7 @@ description = "Notebook has no markdown cells for documentation"
 suggestion = "Add markdown cells to document your notebook"
 category = "Notebook"
 tags = ["notebook", "style", "documentation"]
+platform = "all"
 
 [context]
 type = "no_markdown"

--- a/src/burnt-engine/rules/observability/BO001_print_action_result.toml
+++ b/src/burnt-engine/rules/observability/BO001_print_action_result.toml
@@ -1,0 +1,35 @@
+[rule]
+id = "print_action_result"
+code = "BO001"
+severity = "warning"
+language = "python"
+description = "print() of a Spark action result triggers a full job and discards the data — use logging or display() instead"
+suggestion = "Use logging.info() or display() (Databricks) to surface results; avoid print() around expensive Spark actions"
+category = "Observability"
+tags = ["pyspark", "observability", "logging"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (identifier) @fn
+  arguments: (argument_list
+    (call
+      function: (attribute
+        object: (_)
+        attribute: (identifier) @action)))
+  (#eq? @fn "print")
+  (#match? @action "^(collect|count|first|take|toPandas|toLocalIterator)$"))
+"""
+
+[tests]
+pass = [
+    "logging.info(df.count())",
+    "result = df.collect()",
+    "print('hello world')",
+]
+fail = [
+    "print(df.collect())",
+    "print(df.count())",
+    "print(df.first())",
+]

--- a/src/burnt-engine/rules/observability/BO002_show_in_code.toml
+++ b/src/burnt-engine/rules/observability/BO002_show_in_code.toml
@@ -1,0 +1,30 @@
+[rule]
+id = "show_in_code"
+code = "BO002"
+severity = "info"
+language = "python"
+description = ".show() triggers a full Spark job and should not remain in production pipelines"
+suggestion = "Remove .show() from production code; use display() in notebooks or structured logging in jobs"
+category = "Observability"
+tags = ["pyspark", "observability", "debugging"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @method)
+  (#eq? @method "show"))
+"""
+
+[tests]
+pass = [
+    "df.write.format('delta').save('/data')",
+    "result = df.count()",
+]
+fail = [
+    "df.show()",
+    "df.show(20)",
+    "df.show(truncate=False)",
+]

--- a/src/burnt-engine/rules/observability/BO003_explain_in_code.toml
+++ b/src/burnt-engine/rules/observability/BO003_explain_in_code.toml
@@ -1,0 +1,29 @@
+[rule]
+id = "explain_in_code"
+code = "BO003"
+severity = "info"
+language = "python"
+description = ".explain() is a debugging tool that should not remain in production pipelines"
+suggestion = "Remove .explain() from production code; use Spark UI or structured logging for plan inspection"
+category = "Observability"
+tags = ["pyspark", "observability", "debugging"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @method)
+  (#eq? @method "explain"))
+"""
+
+[tests]
+pass = [
+    "df.write.format('delta').save('/data')",
+]
+fail = [
+    "df.explain()",
+    "df.explain(True)",
+    "df.explain(mode='extended')",
+]

--- a/src/burnt-engine/rules/performance/python/BP001_cell_no_comment.toml
+++ b/src/burnt-engine/rules/performance/python/BP001_cell_no_comment.toml
@@ -7,6 +7,7 @@ description = "Cell has no comments"
 suggestion = "Add comments for clarity"
 category = "BestPractice"
 tags = ["python", "style", "readability"]
+platform = "all"
 
 [context]
 type = "cell_no_comment"

--- a/src/burnt-engine/rules/performance/python/BP002_long_line.toml
+++ b/src/burnt-engine/rules/performance/python/BP002_long_line.toml
@@ -7,6 +7,7 @@ description = "Line exceeds 120 characters"
 suggestion = "Break line for readability"
 category = "BestPractice"
 tags = ["python", "style", "readability"]
+platform = "all"
 
 [context]
 type = "long_line"

--- a/src/burnt-engine/rules/performance/python/BP003_magic_in_plain.toml
+++ b/src/burnt-engine/rules/performance/python/BP003_magic_in_plain.toml
@@ -7,6 +7,7 @@ description = "Databricks magic (# MAGIC) in plain Python file"
 suggestion = "Remove magic or use .py (Databricks) extension"
 category = "BestPractice"
 tags = ["python", "databricks", "magic"]
+platform = "databricks"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/performance/python/BP004_deprecated_magic.toml
+++ b/src/burnt-engine/rules/performance/python/BP004_deprecated_magic.toml
@@ -7,6 +7,7 @@ description = "Deprecated Databricks magic syntax used"
 suggestion = "Use new-style magic format"
 category = "BestPractice"
 tags = ["python", "databricks", "magic"]
+platform = "databricks"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/performance/python/BP008_collect_without_limit.toml
+++ b/src/burnt-engine/rules/performance/python/BP008_collect_without_limit.toml
@@ -14,6 +14,7 @@ description = "collect() without limit() can OOM the driver"
 suggestion = "Add .limit(n).collect() or use .take(n)"
 category = "BestPractice"
 tags = ["pyspark", "memory", "driver-bound"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/performance/python/BP010_python_udf.toml
+++ b/src/burnt-engine/rules/performance/python/BP010_python_udf.toml
@@ -14,6 +14,7 @@ description = "Python UDF has 10-100x overhead vs Pandas UDF"
 suggestion = "Use @pandas_udf for vectorized operations"
 category = "BestPractice"
 tags = ["pyspark", "udf", "performance"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/performance/python/BP011_to_pandas.toml
+++ b/src/burnt-engine/rules/performance/python/BP011_to_pandas.toml
@@ -14,6 +14,7 @@ description = "toPandas() brings the entire DataFrame to the driver"
 suggestion = "Add .limit(n).toPandas() or use Spark-native aggregations"
 category = "BestPractice"
 tags = ["pyspark", "memory", "driver-bound"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/performance/python/BP012_repartition_one.toml
+++ b/src/burnt-engine/rules/performance/python/BP012_repartition_one.toml
@@ -14,6 +14,7 @@ description = "repartition(1) forces all data through a single partition"
 suggestion = "Use coalesce(1) when reducing partitions, or keep natural parallelism"
 category = "BestPractice"
 tags = ["pyspark", "partitioning", "shuffle"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/performance/python/BP014_cross_join.toml
+++ b/src/burnt-engine/rules/performance/python/BP014_cross_join.toml
@@ -14,6 +14,7 @@ description = "CROSS JOIN creates O(n*m) rows"
 suggestion = "Use INNER JOIN with explicit ON clause"
 category = "BestPractice"
 tags = ["pyspark", "join", "shuffle"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/performance/python/BP015_pandas_udf.toml
+++ b/src/burnt-engine/rules/performance/python/BP015_pandas_udf.toml
@@ -14,6 +14,7 @@ description = "pandas_udf still serialises data via Arrow — consider Spark-nat
 suggestion = "Use built-in Spark SQL functions where available"
 category = "BestPractice"
 tags = ["pyspark", "udf", "arrow"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/performance/python/BP016_count_without_filter.toml
+++ b/src/burnt-engine/rules/performance/python/BP016_count_without_filter.toml
@@ -14,6 +14,7 @@ description = "count() without filter scans the entire table"
 suggestion = "Apply .filter() or .where() before count()"
 category = "BestPractice"
 tags = ["pyspark", "performance", "full-scan"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/performance/python/BP020_with_column_in_loop.toml
+++ b/src/burnt-engine/rules/performance/python/BP020_with_column_in_loop.toml
@@ -14,6 +14,7 @@ description = ".withColumn() inside a loop causes O(n²) Catalyst plan analysis"
 suggestion = "Use .withColumns() (Spark 3.3+) or a single .select() statement"
 category = "BestPractice"
 tags = ["pyspark", "catalyst", "loop"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/performance/python/BP021_jdbc_incomplete_partition.toml
+++ b/src/burnt-engine/rules/performance/python/BP021_jdbc_incomplete_partition.toml
@@ -7,6 +7,7 @@ description = "JDBC read missing required partition options — reads entire tab
 suggestion = "Add partitionColumn, numPartitions, lowerBound, and upperBound options"
 category = "BestPractice"
 tags = ["pyspark", "jdbc", "performance"]
+platform = "all"
 
 [context]
 type = "jdbc_partition"

--- a/src/burnt-engine/rules/performance/python/BP022_sdp_prohibited_ops.toml
+++ b/src/burnt-engine/rules/performance/python/BP022_sdp_prohibited_ops.toml
@@ -7,6 +7,7 @@ description = "Prohibited operation inside Spark Declarative Pipeline function"
 suggestion = "Remove this operation from SDP pipeline code"
 category = "BestPractice"
 tags = ["pyspark", "sdp", "dlt"]
+platform = "databricks"
 
 [context]
 type = "sdp_prohibited_ops"

--- a/src/burnt-engine/rules/performance/python/BP023_window_without_partition_by.toml
+++ b/src/burnt-engine/rules/performance/python/BP023_window_without_partition_by.toml
@@ -7,6 +7,7 @@ description = "Window.orderBy() without .partitionBy() causes global sort"
 suggestion = "Add .partitionBy() before .orderBy() or use .orderBy().limit()"
 category = "BestPractice"
 tags = ["pyspark", "window", "shuffle"]
+platform = "all"
 
 [context]
 type = "window_partition"

--- a/src/burnt-engine/rules/performance/python/BP030_cache_without_unpersist.toml
+++ b/src/burnt-engine/rules/performance/python/BP030_cache_without_unpersist.toml
@@ -14,6 +14,7 @@ description = ".cache() with no .unpersist() in the same scope — potential mem
 suggestion = "Call .unpersist() when the cached DataFrame is no longer needed"
 category = "BestPractice"
 tags = ["pyspark", "memory", "caching"]
+platform = "all"
 
 [dataflow]
 type = "cache_lifecycle"

--- a/src/burnt-engine/rules/performance/python/BP031_single_use_cache.toml
+++ b/src/burnt-engine/rules/performance/python/BP031_single_use_cache.toml
@@ -14,6 +14,7 @@ description = ".cache() on a DataFrame used only once adds overhead with no bene
 suggestion = "Remove .cache() if the DataFrame is only used in one action"
 category = "BestPractice"
 tags = ["pyspark", "memory", "caching"]
+platform = "all"
 
 [dataflow]
 type = "cache_lifecycle"

--- a/src/burnt-engine/rules/performance/python/BP032_repeated_actions_no_cache.toml
+++ b/src/burnt-engine/rules/performance/python/BP032_repeated_actions_no_cache.toml
@@ -7,6 +7,7 @@ description = "Same DataFrame has 2+ action calls without .cache() — plan exec
 suggestion = "Call .cache() before the first action and .unpersist() afterward"
 category = "BestPractice"
 tags = ["pyspark", "performance", "caching"]
+platform = "all"
 
 [dataflow]
 type = "repeated_actions"

--- a/src/burnt-engine/rules/performance/python/BP040_shuffle_partitions_hardcoded.toml
+++ b/src/burnt-engine/rules/performance/python/BP040_shuffle_partitions_hardcoded.toml
@@ -1,0 +1,36 @@
+[rule]
+id = "shuffle_partitions_hardcoded"
+code = "BP040"
+severity = "warning"
+language = "python"
+description = "spark.sql.shuffle.partitions hardcoded to 200 disables AQE partition coalescing"
+suggestion = "Remove the hardcoded value or raise to ≥800 so AQE can coalesce dynamically"
+category = "BestPractice"
+tags = ["pyspark", "performance", "shuffle", "config", "aqe"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (identifier)
+      attribute: (identifier) @conf)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (string) @key
+    (string) @val)
+  (#eq? @conf "conf")
+  (#eq? @method "set")
+  (#match? @key "shuffle\\.partitions")
+  (#match? @val "200"))
+"""
+
+[tests]
+pass = [
+    "spark.conf.set(\"spark.sql.shuffle.partitions\", \"800\")",
+    "spark.conf.set(\"spark.sql.shuffle.partitions\", \"auto\")",
+]
+fail = [
+    "spark.conf.set(\"spark.sql.shuffle.partitions\", \"200\")",
+]

--- a/src/burnt-engine/rules/performance/python/BP041_aqe_disabled.toml
+++ b/src/burnt-engine/rules/performance/python/BP041_aqe_disabled.toml
@@ -1,0 +1,35 @@
+[rule]
+id = "aqe_disabled"
+code = "BP041"
+severity = "warning"
+language = "python"
+description = "Disabling AQE removes runtime skew handling, partition coalescing and SMJ→BHJ conversion"
+suggestion = "Remove this config or set it to true; AQE is enabled by default on Spark 3.2+"
+category = "BestPractice"
+tags = ["pyspark", "performance", "shuffle", "config", "aqe"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (identifier)
+      attribute: (identifier) @conf)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (string) @key
+    (string) @val)
+  (#eq? @conf "conf")
+  (#eq? @method "set")
+  (#match? @key "adaptive\\.enabled")
+  (#match? @val "false"))
+"""
+
+[tests]
+pass = [
+    "spark.conf.set(\"spark.sql.adaptive.enabled\", \"true\")",
+]
+fail = [
+    "spark.conf.set(\"spark.sql.adaptive.enabled\", \"false\")",
+]

--- a/src/burnt-engine/rules/performance/python/BP042_unnecessary_broadcast.toml
+++ b/src/burnt-engine/rules/performance/python/BP042_unnecessary_broadcast.toml
@@ -1,0 +1,33 @@
+[rule]
+id = "unnecessary_broadcast"
+code = "BP042"
+severity = "info"
+language = "python"
+description = "Explicit broadcast() hints can backfire — AQE automatically broadcasts small tables when spark.sql.autoBroadcastJoinThreshold is set"
+suggestion = "Remove the explicit broadcast() hint and let AQE decide, or verify the table is genuinely small enough to broadcast"
+category = "Performance"
+tags = ["pyspark", "join", "aqe", "broadcast"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @fn)
+  (#eq? @fn "broadcast"))
+
+(call
+  function: (identifier) @fn
+  (#eq? @fn "broadcast"))
+"""
+
+[tests]
+pass = [
+    "df.join(other, 'id', 'left')",
+    "df.join(other.hint('broadcast'), 'id')",
+]
+fail = [
+    "df.join(broadcast(small_df), 'id')",
+    "joined = F.broadcast(lookup_df)",
+]

--- a/src/burnt-engine/rules/performance/python/BP044_skew_join_disabled.toml
+++ b/src/burnt-engine/rules/performance/python/BP044_skew_join_disabled.toml
@@ -1,0 +1,35 @@
+[rule]
+id = "skew_join_disabled"
+code = "BP044"
+severity = "warning"
+language = "python"
+description = "Disabling AQE skew join handling prevents automatic splitting of skewed sort-merge join tasks"
+suggestion = "Remove this config or set it to true"
+category = "BestPractice"
+tags = ["pyspark", "performance", "shuffle", "config", "aqe"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (identifier)
+      attribute: (identifier) @conf)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (string) @key
+    (string) @val)
+  (#eq? @conf "conf")
+  (#eq? @method "set")
+  (#match? @key "skewJoin\\.enabled")
+  (#match? @val "false"))
+"""
+
+[tests]
+pass = [
+    "spark.conf.set(\"spark.sql.adaptive.skewJoin.enabled\", \"true\")",
+]
+fail = [
+    "spark.conf.set(\"spark.sql.adaptive.skewJoin.enabled\", \"false\")",
+]

--- a/src/burnt-engine/rules/performance/python/BP045_coalesce_partitions_disabled.toml
+++ b/src/burnt-engine/rules/performance/python/BP045_coalesce_partitions_disabled.toml
@@ -1,0 +1,35 @@
+[rule]
+id = "coalesce_partitions_disabled"
+code = "BP045"
+severity = "warning"
+language = "python"
+description = "Disabling AQE partition coalescing forfeits the principal AQE benefit: small post-shuffle task amalgamation"
+suggestion = "Remove this config or set it to true"
+category = "BestPractice"
+tags = ["pyspark", "performance", "shuffle", "config", "aqe"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (identifier)
+      attribute: (identifier) @conf)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (string) @key
+    (string) @val)
+  (#eq? @conf "conf")
+  (#eq? @method "set")
+  (#match? @key "coalescePartitions\\.enabled")
+  (#match? @val "false"))
+"""
+
+[tests]
+pass = [
+    "spark.conf.set(\"spark.sql.adaptive.coalescePartitions.enabled\", \"true\")",
+]
+fail = [
+    "spark.conf.set(\"spark.sql.adaptive.coalescePartitions.enabled\", \"false\")",
+]

--- a/src/burnt-engine/rules/performance/python/BP046_broadcast_threshold_disabled.toml
+++ b/src/burnt-engine/rules/performance/python/BP046_broadcast_threshold_disabled.toml
@@ -1,0 +1,35 @@
+[rule]
+id = "broadcast_threshold_disabled"
+code = "BP046"
+severity = "info"
+language = "python"
+description = "Setting autoBroadcastJoinThreshold to -1 disables all automatic broadcast joins, forcing every dimension join to shuffle"
+suggestion = "Lower the threshold (e.g. 50MB) instead of disabling entirely"
+category = "BestPractice"
+tags = ["pyspark", "performance", "config", "aqe"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (identifier)
+      attribute: (identifier) @conf)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (string) @key
+    (string) @val)
+  (#eq? @conf "conf")
+  (#eq? @method "set")
+  (#match? @key "autoBroadcastJoinThreshold")
+  (#match? @val "-1"))
+"""
+
+[tests]
+pass = [
+    "spark.conf.set(\"spark.sql.autoBroadcastJoinThreshold\", \"52428800\")",
+]
+fail = [
+    "spark.conf.set(\"spark.sql.autoBroadcastJoinThreshold\", \"-1\")",
+]

--- a/src/burnt-engine/rules/performance/python/BP050_infer_schema_csv_json.toml
+++ b/src/burnt-engine/rules/performance/python/BP050_infer_schema_csv_json.toml
@@ -1,0 +1,34 @@
+[rule]
+id = "infer_schema_csv_json"
+code = "BP050"
+severity = "warning"
+language = "python"
+description = "inferSchema=True forces Spark to read the entire file twice — a 2× I/O multiplier on large CSV/JSON"
+suggestion = "Define an explicit StructType schema or convert to Parquet/Delta once"
+category = "BestPractice"
+tags = ["pyspark", "performance", "correctness", "io"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (keyword_argument
+      name: (identifier) @kw
+      value: (true)))
+  (#match? @method "^(csv|json)$")
+  (#eq? @kw "inferSchema"))
+"""
+
+[tests]
+pass = [
+    "df = spark.read.schema(schema).csv(path)",
+    "df = spark.read.csv(path, inferSchema=False)",
+]
+fail = [
+    "df = spark.read.csv(path, inferSchema=True)",
+    "df = spark.read.json(path, inferSchema=True)",
+]

--- a/src/burnt-engine/rules/performance/python/BP051_merge_schema_on_read.toml
+++ b/src/burnt-engine/rules/performance/python/BP051_merge_schema_on_read.toml
@@ -1,0 +1,33 @@
+[rule]
+id = "merge_schema_on_read"
+code = "BP051"
+severity = "warning"
+language = "python"
+description = "mergeSchema=true reads metadata from every file to compute the union schema — kills planning time on large partitioned tables"
+suggestion = "Use an explicit schema or ensure all files share the same schema"
+category = "BestPractice"
+tags = ["pyspark", "performance", "delta", "io"]
+platform = "delta"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @opt)
+  arguments: (argument_list
+    (string) @key
+    (string) @val)
+  (#eq? @opt "option")
+  (#match? @key "mergeSchema")
+  (#match? @val "true"))
+"""
+
+[tests]
+pass = [
+    "df = spark.read.format(\"delta\").load(path)",
+    "df = spark.read.option(\"mergeSchema\", \"false\").format(\"delta\").load(path)",
+]
+fail = [
+    "df = spark.read.option(\"mergeSchema\", \"true\").format(\"delta\").load(path)",
+]

--- a/src/burnt-engine/rules/performance/python/BP052_readstream_no_schema.toml
+++ b/src/burnt-engine/rules/performance/python/BP052_readstream_no_schema.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "readstream_no_schema"
+code = "BP052"
+severity = "warning"
+language = "python"
+description = "readStream on JSON/CSV/Avro without an explicit schema triggers schema inference on every micro-batch restart"
+suggestion = "Provide an explicit schema: .schema(my_schema) before .load() to avoid costly inference and ensure stability"
+category = "Performance"
+tags = ["pyspark", "streaming", "schema", "performance"]
+platform = "all"
+
+[context]
+type = "readstream_no_schema"
+
+[tests]
+pass = [
+    "spark.readStream.schema(my_schema).format('json').load(path)",
+    "spark.readStream.format('delta').load(path)",
+]
+fail = [
+    "spark.readStream.format('json').load(path)",
+    "spark.readStream.format('csv').option('header', 'true').load(path)",
+]

--- a/src/burnt-engine/rules/performance/python/BP053_csv_json_no_schema.toml
+++ b/src/burnt-engine/rules/performance/python/BP053_csv_json_no_schema.toml
@@ -1,0 +1,33 @@
+[rule]
+id = "csv_json_no_schema"
+code = "BP053"
+severity = "warning"
+language = "python"
+description = "Reading CSV or JSON without an explicit schema forces Spark to scan the data to infer types"
+suggestion = "Call .schema(StructType([...])) before .csv()/.json() to avoid the extra scan and ensure type safety"
+category = "BestPractice"
+tags = ["pyspark", "performance", "schema"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (_)
+      attribute: (identifier) @read)
+    attribute: (identifier) @fmt)
+  (#eq? @read "read")
+  (#match? @fmt "^(csv|json)$"))
+"""
+
+[tests]
+pass = [
+    "spark.read.schema(schema).csv('/data/path')",
+    "spark.read.schema(schema).json('/data/path')",
+    "spark.read.parquet('/data/path')",
+]
+fail = [
+    "spark.read.csv('/data/path')",
+    "spark.read.json('/data/path')",
+]

--- a/src/burnt-engine/rules/performance/python/BP060_filter_after_cache.toml
+++ b/src/burnt-engine/rules/performance/python/BP060_filter_after_cache.toml
@@ -1,0 +1,22 @@
+[rule]
+id = "filter_after_cache"
+code = "BP060"
+severity = "warning"
+language = "python"
+description = ".filter() applied after .cache() forces a full scan of the cached data; cache the filtered DataFrame instead"
+suggestion = "Apply .filter() before .cache() so only the relevant rows are stored in memory"
+category = "Performance"
+tags = ["pyspark", "cache", "filter", "performance"]
+platform = "all"
+
+[dataflow]
+type = "filter_after_cache"
+
+[tests]
+pass = [
+    "cached_df = df.filter(col('x') > 10).cache()\nresult = cached_df.collect()",
+]
+fail = [
+    "cached_df = df.cache()\nresult = cached_df.filter(col('x') > 10).collect()",
+    "big_df = spark.read.parquet(path).cache()\nbig_df.filter('date > 2024').show()",
+]

--- a/src/burnt-engine/rules/performance/python/BP070_redundant_operation_chain.toml
+++ b/src/burnt-engine/rules/performance/python/BP070_redundant_operation_chain.toml
@@ -1,0 +1,33 @@
+[rule]
+id = "redundant_operation_chain"
+code = "BP070"
+severity = "info"
+language = "python"
+description = "Chained identical operations (.distinct().distinct() or .sort().sort()) waste a full shuffle stage"
+suggestion = "Remove the redundant operation"
+category = "BestPractice"
+tags = ["pyspark", "performance", "shuffle"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (call
+      function: (attribute
+        object: (_)
+        attribute: (identifier) @inner))
+    attribute: (identifier) @outer)
+  (#eq? @inner @outer)
+  (#match? @inner "^(distinct|sort|orderBy|order_by)$"))
+"""
+
+[tests]
+pass = [
+    "df.distinct().sort('id')",
+    "df.orderBy('a').filter(col('b') > 0)",
+]
+fail = [
+    "df.distinct().distinct()",
+    "df.sort('id').sort('id')",
+]

--- a/src/burnt-engine/rules/performance/python/BP071_drop_duplicates_no_subset.toml
+++ b/src/burnt-engine/rules/performance/python/BP071_drop_duplicates_no_subset.toml
@@ -1,0 +1,30 @@
+[rule]
+id = "drop_duplicates_no_subset"
+code = "BP071"
+severity = "warning"
+language = "python"
+description = "dropDuplicates() without a subset deduplicates on all columns, which is rarely intended and always expensive"
+suggestion = "Pass an explicit subset: dropDuplicates(['id', 'event_time'])"
+category = "BestPractice"
+tags = ["pyspark", "correctness", "performance"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @method)
+  arguments: (argument_list) @args
+  (#eq? @method "dropDuplicates")
+  (#not-match? @args "[a-zA-Z_]"))
+"""
+
+[tests]
+pass = [
+    "df.dropDuplicates(subset=['id', 'email'])",
+    "df.dropDuplicates(['id'])",
+]
+fail = [
+    "df.dropDuplicates()",
+]

--- a/src/burnt-engine/rules/performance/python/BP072_groupby_agg_filter.toml
+++ b/src/burnt-engine/rules/performance/python/BP072_groupby_agg_filter.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "groupby_agg_filter"
+code = "BP072"
+severity = "info"
+language = "python"
+description = ".filter() after .agg() is equivalent to SQL HAVING — using filter on post-agg columns is correct but this is a style flag"
+suggestion = "If filtering on aggregated columns, this is fine; if filtering on non-aggregated columns, move the filter before groupBy for better performance"
+category = "Performance"
+tags = ["pyspark", "groupby", "filter", "performance"]
+platform = "all"
+
+[context]
+type = "groupby_agg_filter"
+
+[tests]
+pass = [
+    "df.filter('age > 18').groupBy('dept').agg(count('*'))",
+    "df.groupBy('dept').agg(count('*'))",
+]
+fail = [
+    "df.groupBy('dept').agg(count('*').alias('cnt')).filter('cnt > 100')",
+    "df.groupBy('category').agg(sum('amount')).filter(col('sum(amount)') > 1000)",
+]

--- a/src/burnt-engine/rules/performance/python/BP073_orderby_before_shuffle.toml
+++ b/src/burnt-engine/rules/performance/python/BP073_orderby_before_shuffle.toml
@@ -1,0 +1,24 @@
+[rule]
+id = "orderby_before_shuffle"
+code = "BP073"
+severity = "warning"
+language = "python"
+description = ".orderBy() before a shuffle operation (groupBy/join/repartition) is discarded — the shuffle destroys the sort order"
+suggestion = "Remove the .orderBy() before shuffle operations; apply sorting after the shuffle if order is required"
+category = "Performance"
+tags = ["pyspark", "orderby", "shuffle", "performance"]
+platform = "all"
+
+[context]
+type = "orderby_before_shuffle"
+
+[tests]
+pass = [
+    "df.groupBy('dept').agg(count('*')).orderBy('count(1)')",
+    "df.join(other, 'id').orderBy('date')",
+]
+fail = [
+    "df.orderBy('date').groupBy('dept').agg(count('*'))",
+    "df.orderBy('id').join(other, 'id')",
+    "df.orderBy('col').repartition(10)",
+]

--- a/src/burnt-engine/rules/performance/python/BP074_single_withcolumn.toml
+++ b/src/burnt-engine/rules/performance/python/BP074_single_withcolumn.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "single_withcolumn"
+code = "BP074"
+severity = "info"
+language = "python"
+description = "Multiple chained .withColumn() calls each add a Project node — use .withColumns({}) to add all columns in one step"
+suggestion = "Replace multiple .withColumn() calls with a single .withColumns({'col1': expr1, 'col2': expr2})"
+category = "Performance"
+tags = ["pyspark", "withColumn", "performance"]
+platform = "all"
+
+[context]
+type = "single_withcolumn"
+
+[tests]
+pass = [
+    "df.withColumns({'a': col('x') + 1, 'b': col('y') * 2})",
+    "df.withColumn('a', col('x') + 1)",
+]
+fail = [
+    "df.withColumn('a', col('x') + 1).withColumn('b', col('y') * 2).withColumn('c', lit(0))",
+    "df.withColumn('flag', lit(True)).withColumn('ts', current_timestamp()).withColumn('id', monotonically_increasing_id())",
+]

--- a/src/burnt-engine/rules/performance/python/BP080_pandas_pyspark_mix.toml
+++ b/src/burnt-engine/rules/performance/python/BP080_pandas_pyspark_mix.toml
@@ -1,0 +1,22 @@
+[rule]
+id = "pandas_pyspark_mix"
+code = "BP080"
+severity = "warning"
+language = "python"
+description = "Mixing pyspark.pandas and pandas in the same file causes implicit .to_pandas() / .to_spark() conversions"
+suggestion = "Use pyspark.pandas (Koalas API) exclusively, or convert to Spark DataFrame at the boundary and stay in Spark"
+category = "Performance"
+tags = ["pyspark", "pandas", "performance"]
+platform = "all"
+
+[context]
+type = "pandas_pyspark_mix"
+
+[tests]
+pass = [
+    "import pyspark.pandas as ps\ndf = ps.read_csv('data.csv')",
+    "import pandas as pd\ndf = pd.read_csv('data.csv')",
+]
+fail = [
+    "import pyspark.pandas as ps\nimport pandas as pd\ndf = ps.from_pandas(pd.DataFrame({'a': [1]}))",
+]

--- a/src/burnt-engine/rules/performance/python/BP081_pandas_roundtrip.toml
+++ b/src/burnt-engine/rules/performance/python/BP081_pandas_roundtrip.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "pandas_roundtrip"
+code = "BP081"
+severity = "warning"
+language = "python"
+description = ".to_pandas() followed by .to_spark() materialises the entire DataFrame to the driver and back — an expensive round-trip"
+suggestion = "Keep data in Spark; use Spark built-in functions or pandas UDFs instead of converting to pandas and back"
+category = "Performance"
+tags = ["pyspark", "pandas", "performance"]
+platform = "all"
+
+[context]
+type = "pandas_roundtrip"
+
+[tests]
+pass = [
+    "result = df.toPandas()",
+    "spark_df = ps_df.to_spark()",
+]
+fail = [
+    "result = df.toPandas().to_spark()",
+    "pdf = df.to_pandas()\nspark_df = pdf.to_spark()",
+]

--- a/src/burnt-engine/rules/performance/python/BP090_monotonically_increasing_id_join.toml
+++ b/src/burnt-engine/rules/performance/python/BP090_monotonically_increasing_id_join.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "monotonically_increasing_id_join"
+code = "BP090"
+severity = "warning"
+language = "python"
+description = "monotonically_increasing_id() used as a join key — IDs are not stable across recomputation and differ between runs"
+suggestion = "Use a deterministic business key or UUID seeded from existing columns instead of monotonically_increasing_id()"
+category = "Correctness"
+tags = ["pyspark", "join", "correctness", "determinism"]
+platform = "all"
+
+[context]
+type = "monotonically_increasing_id_join"
+
+[tests]
+pass = [
+    "df.withColumn('id', col('business_key'))",
+    "df.join(other, 'stable_id')",
+]
+fail = [
+    "df.withColumn('row_id', monotonically_increasing_id()).join(other, 'row_id')",
+    "df2 = df.withColumn('id', monotonically_increasing_id())\ndf2.join(lookup, 'id')",
+]

--- a/src/burnt-engine/rules/performance/python/BP091_current_timestamp_in_cache.toml
+++ b/src/burnt-engine/rules/performance/python/BP091_current_timestamp_in_cache.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "current_timestamp_in_cache"
+code = "BP091"
+severity = "warning"
+language = "python"
+description = "current_timestamp() or now() inside a cached DataFrame returns the evaluation time, not query time — cached values become stale"
+suggestion = "Materialise the timestamp before caching, or avoid caching DataFrames that contain current_timestamp()/now()"
+category = "Correctness"
+tags = ["pyspark", "cache", "correctness", "determinism"]
+platform = "all"
+
+[context]
+type = "current_timestamp_in_cache"
+
+[tests]
+pass = [
+    "df.withColumn('ts', lit('2024-01-01')).cache()",
+    "df.withColumn('ts', current_timestamp())",
+]
+fail = [
+    "df.withColumn('ts', current_timestamp()).cache()",
+    "df.withColumn('now', F.now()).cache()",
+]

--- a/src/burnt-engine/rules/performance/python/BP092_rand_without_seed.toml
+++ b/src/burnt-engine/rules/performance/python/BP092_rand_without_seed.toml
@@ -1,0 +1,31 @@
+[rule]
+id = "rand_without_seed"
+code = "BP092"
+severity = "warning"
+language = "python"
+description = "rand()/randn() without a seed produces non-reproducible results across runs and rerenders"
+suggestion = "Pass an explicit integer seed: rand(seed=42)"
+category = "BestPractice"
+tags = ["pyspark", "correctness"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @fn)
+  arguments: (argument_list) @args
+  (#match? @fn "^rand[n]?$")
+  (#not-match? @args "[a-zA-Z_]"))
+"""
+
+[tests]
+pass = [
+    "F.rand(seed=42)",
+    "F.randn(seed=0)",
+]
+fail = [
+    "F.rand()",
+    "F.randn()",
+]

--- a/src/burnt-engine/rules/performance/python/BP093_uuid_in_transformation.toml
+++ b/src/burnt-engine/rules/performance/python/BP093_uuid_in_transformation.toml
@@ -1,0 +1,28 @@
+[rule]
+id = "uuid_in_transformation"
+code = "BP093"
+severity = "info"
+language = "python"
+description = "uuid() generates a different value on every recomputation of the same lineage — results differ across retries and rerenders"
+suggestion = "Generate UUIDs once, persist to Delta, then read back; or use monotonically_increasing_id() for row IDs"
+category = "BestPractice"
+tags = ["pyspark", "correctness", "style"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @fn)
+  arguments: (argument_list)
+  (#eq? @fn "uuid"))
+"""
+
+[tests]
+pass = [
+    "df.withColumn('id', F.monotonically_increasing_id())",
+]
+fail = [
+    "df.withColumn('uid', F.uuid())",
+]

--- a/src/burnt-engine/rules/performance/python/BP094_input_file_name_as_key.toml
+++ b/src/burnt-engine/rules/performance/python/BP094_input_file_name_as_key.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "input_file_name_as_key"
+code = "BP094"
+severity = "warning"
+language = "python"
+description = "input_file_name() used as a partition or join key — file names vary by run and cluster, making results non-deterministic"
+suggestion = "Extract stable identifiers from the file content rather than using input_file_name() as a key"
+category = "Correctness"
+tags = ["pyspark", "join", "partition", "correctness", "determinism"]
+platform = "all"
+
+[context]
+type = "input_file_name_as_key"
+
+[tests]
+pass = [
+    "df.withColumn('source_file', input_file_name())",
+    "df.partitionBy('date').save(path)",
+]
+fail = [
+    "df.withColumn('file_key', input_file_name()).join(other, 'file_key')",
+    "df.withColumn('fname', input_file_name()).write.partitionBy('fname').save(path)",
+]

--- a/src/burnt-engine/rules/performance/python/BP100_python_udf_photon.toml
+++ b/src/burnt-engine/rules/performance/python/BP100_python_udf_photon.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "python_udf_photon"
+code = "BP100"
+severity = "warning"
+language = "python"
+description = "Python UDFs disable Photon acceleration — each row serialized to Python and back"
+suggestion = "Rewrite the UDF using Spark built-in functions or use a Pandas UDF (Arrow-based) for better Photon compatibility"
+category = "Performance"
+tags = ["pyspark", "udf", "photon", "databricks"]
+platform = "databricks"
+
+[context]
+type = "python_udf_photon"
+
+[tests]
+pass = [
+    "df.select(upper(col('name')))",
+    "@pandas_udf(StringType())\ndef my_udf(s): return s.str.upper()",
+]
+fail = [
+    "@udf(returnType=StringType())\ndef my_udf(x): return x.upper()",
+    "my_fn = udf(lambda x: x * 2, IntegerType())",
+]

--- a/src/burnt-engine/rules/performance/python/BP101_rdd_in_dataframe_pipeline.toml
+++ b/src/burnt-engine/rules/performance/python/BP101_rdd_in_dataframe_pipeline.toml
@@ -1,0 +1,30 @@
+[rule]
+id = "rdd_in_dataframe_pipeline"
+code = "BP101"
+severity = "warning"
+language = "python"
+description = "Accessing .rdd on a DataFrame drops out of the optimised DataFrame/Photon path into the Python RDD API"
+suggestion = "Replace .rdd usage with DataFrame API: use .select(), .withColumn(), or pandas UDFs for custom transformations"
+category = "Performance"
+tags = ["pyspark", "performance", "rdd", "photon"]
+platform = "all"
+
+[query]
+detect = """
+((attribute
+  object: (_)
+  attribute: (identifier) @attr)
+ (#eq? @attr "rdd"))
+"""
+
+[tests]
+pass = [
+    "df.select(col('a'))",
+    "df.withColumn('b', col('a') * 2)",
+    "spark.sparkContext.parallelize([1, 2, 3])",
+]
+fail = [
+    "df.rdd.map(lambda r: r[0])",
+    "count = df.rdd.count()",
+    "rows = df.rdd.collect()",
+]

--- a/src/burnt-engine/rules/performance/python/BP102_photon_incompatible_expr.toml
+++ b/src/burnt-engine/rules/performance/python/BP102_photon_incompatible_expr.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "photon_incompatible_expr"
+code = "BP102"
+severity = "info"
+language = "python"
+description = "from_xml() and to_xml() are not supported by Photon — the query falls back to the non-Photon engine"
+suggestion = "If XML parsing is required, pre-process with a pandas UDF or parse outside Spark; otherwise switch to JSON/Avro format"
+category = "Performance"
+tags = ["pyspark", "photon", "xml", "databricks"]
+platform = "databricks"
+
+[context]
+type = "photon_incompatible_expr"
+
+[tests]
+pass = [
+    "df.select(from_json(col('data'), schema))",
+    "df.select(col('value'))",
+]
+fail = [
+    "df.select(from_xml(col('data'), schema))",
+    "df.select(to_xml(col('struct_col')))",
+]

--- a/src/burnt-engine/rules/performance/python/BP110_broadcast_streaming.toml
+++ b/src/burnt-engine/rules/performance/python/BP110_broadcast_streaming.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "broadcast_streaming"
+code = "BP110"
+severity = "error"
+language = "python"
+description = "broadcast() applied to a streaming DataFrame is not supported and causes a StreamingQueryException at runtime"
+suggestion = "Remove broadcast() from streaming DataFrames; Spark Structured Streaming handles stream-static joins automatically"
+category = "Correctness"
+tags = ["pyspark", "streaming", "broadcast", "correctness"]
+platform = "all"
+
+[context]
+type = "broadcast_streaming"
+
+[tests]
+pass = [
+    "df.join(broadcast(small_static_df), 'id')",
+    "stream_df.join(lookup_df, 'id')",
+]
+fail = [
+    "stream_df = spark.readStream.format('delta').load(path)\nbroadcast(stream_df).join(other, 'id')",
+    "joined = broadcast(spark.readStream.load()).join(df, 'id')",
+]

--- a/src/burnt-engine/rules/performance/python/BP111_persist_memory_only.toml
+++ b/src/burnt-engine/rules/performance/python/BP111_persist_memory_only.toml
@@ -1,0 +1,35 @@
+[rule]
+id = "persist_memory_only"
+code = "BP111"
+severity = "warning"
+language = "python"
+description = "StorageLevel.MEMORY_ONLY evicts partitions under memory pressure — lost partitions are recomputed from scratch"
+suggestion = "Use StorageLevel.MEMORY_AND_DISK or StorageLevel.MEMORY_AND_DISK_SER to allow spill to disk"
+category = "Performance"
+tags = ["pyspark", "performance", "cache"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (attribute
+      object: (identifier) @cls
+      attribute: (identifier) @level))
+  (#eq? @method "persist")
+  (#eq? @cls "StorageLevel")
+  (#eq? @level "MEMORY_ONLY"))
+"""
+
+[tests]
+pass = [
+    "df.persist(StorageLevel.MEMORY_AND_DISK)",
+    "df.persist(StorageLevel.MEMORY_AND_DISK_SER)",
+    "df.cache()",
+]
+fail = [
+    "df.persist(StorageLevel.MEMORY_ONLY)",
+]

--- a/src/burnt-engine/rules/performance/python/BP112_tojson_collect.toml
+++ b/src/burnt-engine/rules/performance/python/BP112_tojson_collect.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "tojson_collect"
+code = "BP112"
+severity = "warning"
+language = "python"
+description = ".toJSON().collect() converts every row to a JSON string and pulls all data to the driver — use .toPandas() or write to storage instead"
+suggestion = "Replace .toJSON().collect() with df.toPandas().to_json() for small data, or write directly to storage for large data"
+category = "Performance"
+tags = ["pyspark", "collect", "performance", "driver"]
+platform = "all"
+
+[context]
+type = "tojson_collect"
+
+[tests]
+pass = [
+    "df.write.format('json').save(path)",
+    "pdf = df.toPandas()",
+]
+fail = [
+    "rows = df.toJSON().collect()",
+    "data = df.select('id').toJSON().collect()",
+]

--- a/src/burnt-engine/rules/sdp/SDP001_missing_expectation.toml
+++ b/src/burnt-engine/rules/sdp/SDP001_missing_expectation.toml
@@ -14,6 +14,7 @@ description = "SDP table missing data quality expectation"
 suggestion = "Add @dlt.expect or @dlt.expect_all constraint"
 category = "SDP"
 tags = ["sdp", "data-quality", "declarative"]
+platform = "databricks"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/sdp/SDP002_sdp_incremental_no_key.toml
+++ b/src/burnt-engine/rules/sdp/SDP002_sdp_incremental_no_key.toml
@@ -7,6 +7,7 @@ description = "SDP incremental table defined without a primary key"
 suggestion = "Add keys= parameter to @dlt.table or use APPLY CHANGES INTO"
 category = "SDP"
 tags = ["sdp", "dlt", "incremental"]
+platform = "databricks"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/sdp/SDP003_sdp_streaming_no_schema.toml
+++ b/src/burnt-engine/rules/sdp/SDP003_sdp_streaming_no_schema.toml
@@ -7,6 +7,7 @@ description = "Streaming source missing explicit schema — schema inference on 
 suggestion = "Pass schema= to spark.readStream or use cloudFiles with schemaLocation"
 category = "SDP"
 tags = ["sdp", "streaming", "schema"]
+platform = "databricks"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/sdp/SDP004_materialized_view_full_refresh.toml
+++ b/src/burnt-engine/rules/sdp/SDP004_materialized_view_full_refresh.toml
@@ -7,6 +7,7 @@ description = "Materialized view defined without incremental strategy"
 suggestion = "Consider incremental materialized view for large datasets"
 category = "SDP"
 tags = ["sdp", "dlt", "performance"]
+platform = "databricks"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/sdp/SDP005_missing_table_comment.toml
+++ b/src/burnt-engine/rules/sdp/SDP005_missing_table_comment.toml
@@ -7,6 +7,7 @@ description = "SDP table missing comment metadata"
 suggestion = "Add table comment for documentation"
 category = "SDP"
 tags = ["sdp", "dlt", "documentation"]
+platform = "databricks"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/sdp/SDP006_materialized_view_incremental.toml
+++ b/src/burnt-engine/rules/sdp/SDP006_materialized_view_incremental.toml
@@ -7,6 +7,7 @@ description = "Materialized view defined without incremental strategy"
 suggestion = "Consider incremental materialized view for large datasets"
 category = "SDP"
 tags = ["sdp", "dlt", "incremental", "performance"]
+platform = "databricks"
 
 [context]
 type = "materialized_view_incremental"

--- a/src/burnt-engine/rules/sql/BP013_order_by_without_limit.toml
+++ b/src/burnt-engine/rules/sql/BP013_order_by_without_limit.toml
@@ -7,6 +7,7 @@ description = "ORDER BY without LIMIT sorts the entire result set"
 suggestion = "Add LIMIT or use window functions with RANK/ROW_NUMBER"
 category = "BestPractice"
 tags = ["sql", "performance", "sort"]
+platform = "all"
 
 [context]
 type = "order_by_without_limit"

--- a/src/burnt-engine/rules/sql/BQ001_not_in_with_nulls.toml
+++ b/src/burnt-engine/rules/sql/BQ001_not_in_with_nulls.toml
@@ -14,6 +14,7 @@ description = "NOT IN (subquery) silently returns empty result when the subquery
 suggestion = "Use NOT EXISTS or add WHERE col IS NOT NULL to the subquery"
 category = "SqlQuality"
 tags = ["sql", "correctness", "null-safety"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/sql/BQ002_union_not_all.toml
+++ b/src/burnt-engine/rules/sql/BQ002_union_not_all.toml
@@ -7,6 +7,7 @@ description = "UNION deduplicates rows with an expensive sort — use UNION ALL 
 suggestion = "Replace UNION with UNION ALL"
 category = "SqlQuality"
 tags = ["sql", "performance", "dedup"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/sql/BQ003_count_distinct_at_scale.toml
+++ b/src/burnt-engine/rules/sql/BQ003_count_distinct_at_scale.toml
@@ -7,6 +7,7 @@ description = "COUNT(DISTINCT col) requires full shuffle and sort — expensive 
 suggestion = "Consider approx_count_distinct() for large datasets where exact count is not required"
 category = "SqlQuality"
 tags = ["sql", "performance", "aggregation"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/sql/BQ004_correlated_subquery.toml
+++ b/src/burnt-engine/rules/sql/BQ004_correlated_subquery.toml
@@ -7,20 +7,18 @@ description = "Correlated subquery references outer columns — Spark may execut
 suggestion = "Rewrite as a join or use window functions"
 category = "SqlQuality"
 tags = ["sql", "performance", "subquery"]
+platform = "all"
 
-[query]
-detect = """
-(binary_expression
-  (not_in)
-  (subquery) @inner)
-"""
+[context]
+type = "correlated_subquery"
 
 [tests]
 pass = [
     "SELECT id FROM users WHERE status = 'active'",
     "SELECT id FROM users WHERE id IN (1, 2, 3)",
+    "SELECT * FROM a WHERE id NOT IN (SELECT id FROM b)",
 ]
 fail = [
-    "SELECT * FROM a WHERE id NOT IN (SELECT id FROM b)",
-    "SELECT id FROM orders WHERE customer_id NOT IN (SELECT id FROM customers)",
+    "SELECT * FROM orders WHERE id NOT IN (SELECT order_id FROM items WHERE items.customer_id = orders.id)",
+    "SELECT id FROM a WHERE val NOT IN (SELECT val FROM b WHERE b.group_id = a.group_id)",
 ]

--- a/src/burnt-engine/rules/sql/SQ001_select_star.toml
+++ b/src/burnt-engine/rules/sql/SQ001_select_star.toml
@@ -14,6 +14,7 @@ description = "SELECT * without LIMIT"
 suggestion = "Add LIMIT or specify columns"
 category = "SqlQuality"
 tags = ["sql", "performance", "select-star"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/sql/SQ002_cross_join.toml
+++ b/src/burnt-engine/rules/sql/SQ002_cross_join.toml
@@ -7,6 +7,7 @@ description = "CROSS JOIN without explicit condition"
 suggestion = "Use INNER JOIN with explicit condition"
 category = "SqlQuality"
 tags = ["sql", "join", "cartesian"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/sql/SQ003_cartesian_product.toml
+++ b/src/burnt-engine/rules/sql/SQ003_cartesian_product.toml
@@ -7,6 +7,7 @@ description = "Cartesian product detected"
 suggestion = "Add appropriate join condition"
 category = "SqlQuality"
 tags = ["sql", "join", "cartesian"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/streaming/BS001_writestream_no_checkpoint.toml
+++ b/src/burnt-engine/rules/streaming/BS001_writestream_no_checkpoint.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "writestream_no_checkpoint"
+code = "BS001"
+severity = "error"
+language = "python"
+description = "writeStream without checkpointLocation loses all progress on restart — the stream reprocesses from the beginning"
+suggestion = "Add .option('checkpointLocation', '/path/to/checkpoint') before .start()"
+category = "Streaming"
+tags = ["pyspark", "streaming", "correctness"]
+platform = "all"
+
+[context]
+type = "writestream_no_checkpoint"
+
+[tests]
+pass = [
+    "df.writeStream.option('checkpointLocation', '/tmp/ckpt').start()",
+    "df.writeStream.option('checkpointLocation', checkpoint_path).format('delta').start()",
+]
+fail = [
+    "df.writeStream.format('delta').start()",
+    "df.writeStream.outputMode('append').format('delta').start()",
+]

--- a/src/burnt-engine/rules/streaming/BS002_readstream_no_trigger.toml
+++ b/src/burnt-engine/rules/streaming/BS002_readstream_no_trigger.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "readstream_no_trigger"
+code = "BS002"
+severity = "warning"
+language = "python"
+description = "readStream without .trigger() runs in micro-batch mode at full speed — add a trigger interval to control cost and latency"
+suggestion = "Add .trigger(processingTime='1 minute') or .trigger(availableNow=True) to control batch cadence"
+category = "Streaming"
+tags = ["pyspark", "streaming", "databricks"]
+platform = "databricks"
+
+[context]
+type = "readstream_no_trigger"
+
+[tests]
+pass = [
+    "df.readStream.format('delta').load(path).trigger(processingTime='1 minute').writeStream.start()",
+    "spark.readStream.format('delta').load().trigger(availableNow=True).writeStream.start()",
+]
+fail = [
+    "spark.readStream.format('delta').load(path).writeStream.outputMode('append').start()",
+    "df.readStream.option('header', 'true').load().writeStream.start()",
+]

--- a/src/burnt-engine/rules/streaming/BS003_event_time_no_watermark.toml
+++ b/src/burnt-engine/rules/streaming/BS003_event_time_no_watermark.toml
@@ -1,0 +1,21 @@
+[rule]
+id = "event_time_no_watermark"
+code = "BS003"
+severity = "warning"
+language = "python"
+description = "Event-time aggregation (groupBy(window(...))) without withWatermark causes unbounded state accumulation"
+suggestion = "Add .withWatermark('event_time_col', '10 minutes') before the groupBy to bound the state store"
+category = "Streaming"
+tags = ["pyspark", "streaming", "performance"]
+platform = "all"
+
+[context]
+type = "event_time_no_watermark"
+
+[tests]
+pass = [
+    "df.withWatermark('timestamp', '5 minutes').groupBy(window('timestamp', '1 hour')).agg(count('*'))",
+]
+fail = [
+    "df.groupBy(window('timestamp', '1 hour')).agg(count('*'))",
+]

--- a/src/burnt-engine/rules/streaming/BS004_foreach_batch_no_idempotency.toml
+++ b/src/burnt-engine/rules/streaming/BS004_foreach_batch_no_idempotency.toml
@@ -1,0 +1,21 @@
+[rule]
+id = "foreach_batch_no_idempotency"
+code = "BS004"
+severity = "info"
+language = "python"
+description = "foreachBatch without txnAppId/txnVersion idempotency options may cause duplicate writes on retry"
+suggestion = "Pass txnAppId and txnVersion to Delta writes inside foreachBatch to ensure exactly-once semantics"
+category = "Streaming"
+tags = ["pyspark", "streaming", "correctness"]
+platform = "all"
+
+[context]
+type = "foreach_batch_no_idempotency"
+
+[tests]
+pass = [
+    "df.writeStream.foreachBatch(lambda df, epoch: df.write.option('txnAppId', 'myapp').option('txnVersion', epoch).save(path)).start()",
+]
+fail = [
+    "df.writeStream.foreachBatch(lambda df, epoch: df.write.format('delta').save(path)).start()",
+]

--- a/src/burnt-engine/rules/streaming/BS005_output_mode_complete.toml
+++ b/src/burnt-engine/rules/streaming/BS005_output_mode_complete.toml
@@ -1,0 +1,31 @@
+[rule]
+id = "output_mode_complete"
+code = "BS005"
+severity = "warning"
+language = "python"
+description = "outputMode('complete') recomputes and rewrites the entire result table on every trigger — only valid with aggregation"
+suggestion = "Use outputMode('append') for non-aggregating queries, or ensure an aggregation is upstream of this writeStream"
+category = "Streaming"
+tags = ["pyspark", "streaming", "performance"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (string) @mode)
+  (#eq? @method "outputMode")
+  (#match? @mode "complete"))
+"""
+
+[tests]
+pass = [
+    "df.writeStream.outputMode('append').start()",
+    "df.writeStream.outputMode('update').start()",
+]
+fail = [
+    "df.writeStream.outputMode('complete').start()",
+]

--- a/src/burnt-engine/rules/streaming/BS006_stream_static_join_non_delta.toml
+++ b/src/burnt-engine/rules/streaming/BS006_stream_static_join_non_delta.toml
@@ -1,0 +1,22 @@
+[rule]
+id = "stream_static_join_non_delta"
+code = "BS006"
+severity = "warning"
+language = "python"
+description = "Stream-static join with a non-Delta static side does not automatically pick up updates to the static table"
+suggestion = "Use a Delta table for the static side of stream-static joins so updates are reflected without restarting the stream"
+category = "Streaming"
+tags = ["pyspark", "streaming", "delta", "join"]
+platform = "all"
+
+[context]
+type = "stream_static_join_non_delta"
+
+[tests]
+pass = [
+    "stream_df = spark.readStream.format('delta').load(path)\nstream_df.join(spark.read.format('delta').load(lookup_path), 'id')",
+]
+fail = [
+    "stream_df = spark.readStream.format('delta').load(path)\nstream_df.join(spark.read.format('parquet').load(lookup_path), 'id')",
+    "spark.readStream.load().join(spark.read.csv(path), 'id')",
+]

--- a/src/burnt-engine/rules/style/BNT_A01_todf_splat_rename.toml
+++ b/src/burnt-engine/rules/style/BNT_A01_todf_splat_rename.toml
@@ -1,0 +1,31 @@
+[rule]
+id = "todf_splat_rename"
+code = "BNT-A01"
+severity = "warning"
+language = "python"
+description = ".toDF(*new_names) renames by position and breaks silently if the column count changes"
+suggestion = "Use .withColumnsRenamed({old: new, ...}) or an explicit .select(col('a').alias('x'), ...) for safe renaming"
+category = "Style"
+tags = ["pyspark", "style", "correctness"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (list_splat))
+  (#eq? @method "toDF"))
+"""
+
+[tests]
+pass = [
+    "df.toDF('a', 'b', 'c')",
+    "df.withColumnsRenamed({'old': 'new'})",
+]
+fail = [
+    "df.toDF(*new_names)",
+    "df.toDF(*['x', 'y', 'z'])",
+]

--- a/src/burnt-engine/rules/style/BNT_A02_chained_select_alias.toml
+++ b/src/burnt-engine/rules/style/BNT_A02_chained_select_alias.toml
@@ -1,0 +1,23 @@
+[rule]
+id = "chained_select_alias"
+code = "BNT-A02"
+severity = "info"
+language = "python"
+description = "Multiple chained .select(col('a').alias('b')) calls for renaming — consolidate into a single .toDF() or .withColumnsRenamed()"
+suggestion = "Replace sequential .select().select()... renames with .withColumnsRenamed({'old': 'new', ...}) or .toDF(*new_names)"
+category = "Style"
+tags = ["pyspark", "style", "readability"]
+platform = "all"
+
+[dataflow]
+type = "chained_select_alias"
+
+[tests]
+pass = [
+    "df.select(col('a'), col('b'))",
+    "df.withColumnsRenamed({'old_a': 'a', 'old_b': 'b', 'old_c': 'c'})",
+]
+fail = [
+    "df.select(col('a').alias('x')).select(col('x').alias('y')).select(col('y').alias('z'))",
+    "df.select(col('col1').alias('a')).select(col('a').alias('b')).select(col('b').alias('c'))",
+]

--- a/src/burnt-engine/rules/style/BNT_A03_long_when_chain.toml
+++ b/src/burnt-engine/rules/style/BNT_A03_long_when_chain.toml
@@ -1,0 +1,37 @@
+[rule]
+id = "long_when_chain"
+code = "BNT-A03"
+severity = "info"
+language = "python"
+description = "Long chains of .when().when().when()... are hard to read and maintain"
+suggestion = "Extract the mapping to a Python dict and use create_map() or a lookup join instead"
+category = "Style"
+tags = ["pyspark", "style", "readability"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (call
+      function: (attribute
+        object: (call
+          function: (attribute
+            object: (_)
+            attribute: (identifier) @w3)
+          (#eq? @w3 "when"))
+        attribute: (identifier) @w2)
+      (#eq? @w2 "when"))
+    attribute: (identifier) @w1)
+  (#eq? @w1 "when"))
+"""
+
+[tests]
+pass = [
+    "F.when(col('a') == 1, 'x').otherwise('y')",
+    "F.when(c1, v1).when(c2, v2).otherwise(v3)",
+]
+fail = [
+    "F.when(c1, v1).when(c2, v2).when(c3, v3).otherwise(v4)",
+    "F.when(a, 1).when(b, 2).when(c, 3).when(d, 4).otherwise(0)",
+]

--- a/src/burnt-engine/rules/style/BNT_A04_rdd_map.toml
+++ b/src/burnt-engine/rules/style/BNT_A04_rdd_map.toml
@@ -1,0 +1,32 @@
+[rule]
+id = "rdd_map"
+code = "BNT-A04"
+severity = "warning"
+language = "python"
+description = "df.rdd.map() deserialises rows to Python objects and loses all Spark/Photon optimisations"
+suggestion = "Use df.select() or df.withColumn() with built-in functions instead of df.rdd.map()"
+category = "Style"
+tags = ["pyspark", "performance", "rdd"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (attribute
+      object: (_)
+      attribute: (identifier) @rdd)
+    attribute: (identifier) @map)
+  (#eq? @rdd "rdd")
+  (#eq? @map "map"))
+"""
+
+[tests]
+pass = [
+    "df.select(col('a') * 2)",
+    "df.withColumn('b', col('a') + 1)",
+]
+fail = [
+    "df.rdd.map(lambda r: r['a'] * 2)",
+    "result = df.rdd.map(transform_fn).toDF()",
+]

--- a/src/burnt-engine/rules/style/BNT_C01_df_reference.toml
+++ b/src/burnt-engine/rules/style/BNT_C01_df_reference.toml
@@ -7,6 +7,7 @@ description = "df['col'] or df.col outside a join can cause stale reference bugs
 suggestion = "Use F.col('col') which resolves at evaluation time"
 category = "NotebookStyle"
 tags = ["python", "style", "correctness"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/style/BNT_I01_star_import.toml
+++ b/src/burnt-engine/rules/style/BNT_I01_star_import.toml
@@ -7,6 +7,7 @@ description = "from pyspark.sql.functions import * shadows Python built-ins (max
 suggestion = "Use: from pyspark.sql import functions as F"
 category = "NotebookStyle"
 tags = ["python", "import", "style"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/style/BNT_N01_generic_df_name.toml
+++ b/src/burnt-engine/rules/style/BNT_N01_generic_df_name.toml
@@ -7,6 +7,7 @@ description = "Variable named df/df1-df9 is too generic — hinders readability"
 suggestion = "Use a descriptive name: orders_df, customers, filtered_events"
 category = "NotebookStyle"
 tags = ["python", "style", "naming"]
+platform = "all"
 
 [query]
 detect = """

--- a/src/burnt-engine/rules/testing/BT001_create_dataframe_in_code.toml
+++ b/src/burnt-engine/rules/testing/BT001_create_dataframe_in_code.toml
@@ -1,0 +1,31 @@
+[rule]
+id = "create_dataframe_in_code"
+code = "BT001"
+severity = "info"
+language = "python"
+description = "spark.createDataFrame([...]) with an inline list is a test fixture pattern — avoid in production pipelines"
+suggestion = "Read from Delta tables or external sources in production; keep createDataFrame usage in unit tests"
+category = "Testing"
+tags = ["pyspark", "testing", "hygiene"]
+platform = "all"
+
+[query]
+detect = """
+(call
+  function: (attribute
+    object: (_)
+    attribute: (identifier) @method)
+  arguments: (argument_list
+    (list))
+  (#eq? @method "createDataFrame"))
+"""
+
+[tests]
+pass = [
+    "spark.read.table('catalog.schema.events')",
+    "spark.createDataFrame(rdd, schema)",
+]
+fail = [
+    "spark.createDataFrame([('a', 1), ('b', 2)], ['name', 'val'])",
+    "spark.createDataFrame([{'id': 1}])",
+]

--- a/src/burnt-engine/rules/testing/BT002_hardcoded_credentials.toml
+++ b/src/burnt-engine/rules/testing/BT002_hardcoded_credentials.toml
@@ -1,0 +1,26 @@
+[rule]
+id = "hardcoded_credentials"
+code = "BT002"
+severity = "error"
+language = "python"
+description = "Hardcoded AWS access keys or Databricks tokens found in source"
+suggestion = "Use Databricks Secrets (dbutils.secrets.get), environment variables, or a secrets manager"
+category = "Security"
+tags = ["security", "credentials", "governance"]
+platform = "all"
+
+[query]
+detect = """
+((string) @s
+ (#match? @s "(AKIA[0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z][0-9A-Z]|dapi[a-f0-9]+)"))
+"""
+
+[tests]
+pass = [
+    "token = dbutils.secrets.get('scope', 'key')",
+    "key = os.environ.get('AWS_ACCESS_KEY_ID')",
+]
+fail = [
+    "key = 'AKIAIOSFODNN7EXAMPLE1234'",
+    "token = 'dapi0badcafe'",
+]

--- a/src/burnt-engine/rules/testing/BT003_hardcoded_jdbc_url.toml
+++ b/src/burnt-engine/rules/testing/BT003_hardcoded_jdbc_url.toml
@@ -1,0 +1,26 @@
+[rule]
+id = "hardcoded_jdbc_url"
+code = "BT003"
+severity = "error"
+language = "python"
+description = "JDBC URL with embedded password found in source code"
+suggestion = "Store database credentials in Databricks Secrets and retrieve them at runtime with dbutils.secrets.get()"
+category = "Security"
+tags = ["security", "credentials", "jdbc"]
+platform = "all"
+
+[query]
+detect = """
+((string) @s
+ (#match? @s "jdbc:.*password="))
+"""
+
+[tests]
+pass = [
+    "url = 'jdbc:postgresql://host:5432/db'",
+    "spark.read.jdbc(url, table, properties={'user': user, 'password': pwd})",
+]
+fail = [
+    "url = 'jdbc:postgresql://host:5432/db?user=admin&password=secret'",
+    "url = 'jdbc:sqlserver://server;database=db;password=abc123'",
+]

--- a/src/burnt-engine/src/rules/context.rs
+++ b/src/burnt-engine/src/rules/context.rs
@@ -18,6 +18,36 @@ fn get_dispatch() -> &'static HashMap<&'static str, ContextFn> {
         m.insert("BP023", check_window_without_partition);
         m.insert("BQ004", check_correlated_subquery);
         m.insert("SDP006", check_materialized_view_incremental);
+        // Phase 3 — Tier 2 rules
+        m.insert("BD010", check_overwrite_without_replace_where);
+        m.insert("BD013", check_csv_json_analytical_write);
+        m.insert("BD020", check_optimize_without_where);
+        m.insert("BD021", check_merge_without_partition_predicate);
+        m.insert("BD022", check_merge_update_star_no_filter);
+        m.insert("BD026", check_convert_to_delta_no_optimize);
+        m.insert("BD032", check_too_many_cluster_keys);
+        m.insert("BP080", check_pandas_pyspark_mix);
+        m.insert("BP081", check_pandas_roundtrip);
+        m.insert("BS001", check_writestream_no_checkpoint);
+        m.insert("BS003", check_event_time_no_watermark);
+        m.insert("BS004", check_foreach_batch_no_idempotency);
+        m.insert("BU001", check_two_part_table_name);
+        // Phase 3 — remaining Tier 2 rules
+        m.insert("BD014", check_parquet_write_databricks);
+        m.insert("BS002", check_readstream_no_trigger);
+        m.insert("BS006", check_stream_static_join_non_delta);
+        m.insert("BJ002", check_self_join_no_alias);
+        m.insert("BP052", check_readstream_no_schema);
+        m.insert("BP072", check_groupby_agg_filter);
+        m.insert("BP073", check_orderby_before_shuffle);
+        m.insert("BP074", check_single_withcolumn);
+        m.insert("BP090", check_monotonically_increasing_id_join);
+        m.insert("BP091", check_current_timestamp_in_cache);
+        m.insert("BP094", check_input_file_name_as_key);
+        m.insert("BP100", check_python_udf_photon);
+        m.insert("BP102", check_photon_incompatible_expr);
+        m.insert("BP110", check_broadcast_streaming);
+        m.insert("BP112", check_tojson_collect);
         m
     })
 }
@@ -231,6 +261,600 @@ fn check_correlated_subquery(source: &str) -> Vec<Finding> {
     vec![]
 }
 
+fn check_overwrite_without_replace_where(source: &str) -> Vec<Finding> {
+    let has_overwrite = source.contains(".mode(\"overwrite\")") || source.contains(".mode('overwrite')");
+    let has_delta = source.contains("\"delta\"") || source.contains("'delta'");
+    let has_replace_where = source.contains("replaceWhere") || source.contains("partitionOverwriteMode");
+    if has_overwrite && has_delta && !has_replace_where {
+        vec![make_finding(
+            "BD010",
+            Severity::Warning,
+            "mode('overwrite') on Delta table replaces the entire table — use replaceWhere for partition-level overwrites",
+            "Add .option('replaceWhere', 'partition_col = value') to scope the overwrite",
+            1,
+            Confidence::Medium,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_csv_json_analytical_write(source: &str) -> Vec<Finding> {
+    let has_csv_json_write = (source.contains(".format(\"csv\")") || source.contains(".format('csv')")
+        || source.contains(".format(\"json\")") || source.contains(".format('json')"))
+        && (source.contains(".saveAsTable(") || source.contains(".save("));
+    let is_landing = source.contains("landing") || source.contains("archive") || source.contains("export") || source.contains("raw");
+    if has_csv_json_write && !is_landing {
+        vec![make_finding(
+            "BD013",
+            Severity::Warning,
+            "Writing analytical table as CSV/JSON lacks ACID transactions, schema enforcement, and time travel",
+            "Use .format('delta') for analytical tables; reserve CSV/JSON for landing zones or exports",
+            1,
+            Confidence::Low,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_optimize_without_where(source: &str) -> Vec<Finding> {
+    let upper = source.to_uppercase();
+    if !upper.contains("OPTIMIZE ") {
+        return vec![];
+    }
+    let has_where = upper.contains(" WHERE ");
+    if !has_where {
+        vec![make_finding(
+            "BD020",
+            Severity::Info,
+            "OPTIMIZE without WHERE rewrites the entire table — add a partition predicate to scope the operation",
+            "Add WHERE partition_col >= 'recent_value' to limit files rewritten",
+            1,
+            Confidence::High,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_merge_without_partition_predicate(source: &str) -> Vec<Finding> {
+    let upper = source.to_uppercase();
+    if !upper.contains("MERGE INTO") {
+        return vec![];
+    }
+    let on_start = match upper.find(" ON ") {
+        Some(i) => i,
+        None => return vec![],
+    };
+    let on_clause = match upper.find(" WHEN ") {
+        Some(w) => &upper[on_start..w],
+        None => &upper[on_start..],
+    };
+    // Heuristic: partition predicate has a column *named* date/year/month/day (via `.date`, `_date`
+    // suffix patterns). Avoid substring matches inside table names (e.g. "UPDATES" contains "DATE").
+    let lower_on = on_clause.to_lowercase();
+    let has_partition_hint = lower_on.contains(".date") || lower_on.contains("_date")
+        || lower_on.contains(".year") || lower_on.contains("_year")
+        || lower_on.contains(".month") || lower_on.contains("_month")
+        || lower_on.contains(".day") || lower_on.contains("_day")
+        || lower_on.contains("partition");
+    if !has_partition_hint {
+        vec![make_finding(
+            "BD021",
+            Severity::Warning,
+            "MERGE INTO ON clause may be missing a partition predicate — this causes a full table scan on every merge",
+            "Add a partition column condition to the ON clause (e.g. target.date = source.date)",
+            1,
+            Confidence::Low,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_merge_update_star_no_filter(source: &str) -> Vec<Finding> {
+    let upper = source.to_uppercase();
+    if !upper.contains("MERGE INTO") {
+        return vec![];
+    }
+    let has_update_star = upper.contains("THEN UPDATE SET *") || upper.contains("THEN UPDATE SET*");
+    let has_and_condition = {
+        let when_matched = "WHEN MATCHED";
+        upper.contains(when_matched) && {
+            let idx = upper.find(when_matched).unwrap_or(0);
+            let snippet = &upper[idx..std::cmp::min(idx + 60, upper.len())];
+            snippet.contains(" AND ")
+        }
+    };
+    if has_update_star && !has_and_condition {
+        vec![make_finding(
+            "BD022",
+            Severity::Info,
+            "WHEN MATCHED THEN UPDATE SET * without AND condition updates all matched rows, causing unnecessary rewrites",
+            "Add a change-detection condition: WHEN MATCHED AND source.updated_at > target.updated_at THEN UPDATE SET *",
+            1,
+            Confidence::Medium,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_convert_to_delta_no_optimize(source: &str) -> Vec<Finding> {
+    let upper = source.to_uppercase();
+    if !upper.contains("CONVERT TO DELTA") {
+        return vec![];
+    }
+    if upper.contains("OPTIMIZE") {
+        return vec![];
+    }
+    vec![make_finding(
+        "BD026",
+        Severity::Info,
+        "CONVERT TO DELTA leaves small files from the source format — run OPTIMIZE afterward",
+        "Follow CONVERT TO DELTA with: OPTIMIZE <table_name>",
+        1,
+        Confidence::High,
+    )]
+}
+
+fn check_too_many_cluster_keys(source: &str) -> Vec<Finding> {
+    let upper = source.to_uppercase();
+    let cluster_kw = match upper.find("CLUSTER BY") {
+        Some(i) => i,
+        None => return vec![],
+    };
+    let after = &source[cluster_kw + 10..];
+    let paren_content = if let Some(open) = after.find('(') {
+        let rest = &after[open + 1..];
+        if let Some(close) = rest.find(')') {
+            &rest[..close]
+        } else {
+            rest
+        }
+    } else {
+        after.split_whitespace().next().unwrap_or("")
+    };
+    let key_count = paren_content.split(',').count();
+    if key_count > 4 {
+        vec![make_finding(
+            "BD032",
+            Severity::Warning,
+            "More than 4 Liquid Clustering keys reduces clustering effectiveness and increases write overhead",
+            "Limit CLUSTER BY to the 2-4 most-queried columns",
+            1,
+            Confidence::High,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_pandas_pyspark_mix(source: &str) -> Vec<Finding> {
+    let has_ps = source.contains("pyspark.pandas") || source.contains("import ps");
+    let has_pd = source.contains("import pandas") || (source.contains("import pd") && !source.contains("pyspark"));
+    if has_ps && has_pd {
+        vec![make_finding(
+            "BP080",
+            Severity::Warning,
+            "Mixing pyspark.pandas and pandas in the same file causes implicit serialization round-trips",
+            "Use pyspark.pandas exclusively, or convert at a single boundary and stay in Spark",
+            1,
+            Confidence::Medium,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_pandas_roundtrip(source: &str) -> Vec<Finding> {
+    let has_to_pandas = source.contains(".toPandas()") || source.contains(".to_pandas()");
+    let has_to_spark = source.contains(".to_spark()");
+    if has_to_pandas && has_to_spark {
+        vec![make_finding(
+            "BP081",
+            Severity::Warning,
+            ".to_pandas() followed by .to_spark() materialises the entire DataFrame to the driver and back",
+            "Keep data in Spark; use Spark built-in functions or pandas UDFs instead",
+            1,
+            Confidence::Medium,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_writestream_no_checkpoint(source: &str) -> Vec<Finding> {
+    if !source.contains("writeStream") && !source.contains("write_stream") {
+        return vec![];
+    }
+    if !source.contains(".start(") {
+        return vec![];
+    }
+    if source.contains("checkpointLocation") || source.contains("checkpoint_location") {
+        return vec![];
+    }
+    vec![make_finding(
+        "BS001",
+        Severity::Error,
+        "writeStream without checkpointLocation loses all progress on restart",
+        "Add .option('checkpointLocation', '/path/to/checkpoint') before .start()",
+        1,
+        Confidence::High,
+    )]
+}
+
+fn check_event_time_no_watermark(source: &str) -> Vec<Finding> {
+    let has_window_group = source.contains("groupBy(window(") || source.contains("groupBy( window(");
+    let has_watermark = source.contains("withWatermark(") || source.contains("with_watermark(");
+    if has_window_group && !has_watermark {
+        vec![make_finding(
+            "BS003",
+            Severity::Warning,
+            "Event-time aggregation without withWatermark causes unbounded state accumulation",
+            "Add .withWatermark('event_time_col', '10 minutes') before groupBy(window(...))",
+            1,
+            Confidence::High,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_foreach_batch_no_idempotency(source: &str) -> Vec<Finding> {
+    if !source.contains("foreachBatch(") && !source.contains("foreach_batch(") {
+        return vec![];
+    }
+    let has_idempotency = source.contains("txnAppId") || source.contains("txnVersion");
+    if !has_idempotency {
+        vec![make_finding(
+            "BS004",
+            Severity::Info,
+            "foreachBatch without txnAppId/txnVersion idempotency options may cause duplicate writes on retry",
+            "Add .option('txnAppId', app_name).option('txnVersion', epoch_id) to Delta writes inside foreachBatch",
+            1,
+            Confidence::Low,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_two_part_table_name(source: &str) -> Vec<Finding> {
+    let upper = source.to_uppercase();
+    // Look for FROM/JOIN/INTO/TABLE <word>.<word> without a third part
+    for keyword in &["FROM ", "JOIN ", "INTO ", "TABLE "] {
+        let mut search_pos = 0;
+        while let Some(kw_pos) = upper[search_pos..].find(keyword) {
+            let abs_pos = search_pos + kw_pos;
+            let after = upper[abs_pos + keyword.len()..].trim_start();
+            // Count dots in first token
+            let token: &str = after.split_whitespace().next().unwrap_or("");
+            let dot_count = token.chars().filter(|&c| c == '.').count();
+            if dot_count == 1 && !token.is_empty() {
+                // Two-part name — check it's not a file path or special syntax
+                let first_part = token.split('.').next().unwrap_or("");
+                if !first_part.is_empty() && first_part.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                    return vec![make_finding(
+                        "BU001",
+                        Severity::Warning,
+                        "Two-part table name omits the Unity Catalog prefix — resolves to the default catalog",
+                        "Use three-part naming: catalog.schema.table for explicit catalog resolution",
+                        1,
+                        Confidence::Medium,
+                    )];
+                }
+            }
+            search_pos = abs_pos + keyword.len();
+        }
+    }
+    vec![]
+}
+
+fn check_parquet_write_databricks(source: &str) -> Vec<Finding> {
+    let has_parquet_write = source.contains(".format(\"parquet\")") || source.contains(".format('parquet')");
+    let has_write = source.contains(".write") || source.contains(".saveAsTable(");
+    if has_parquet_write && has_write {
+        vec![make_finding(
+            "BD014",
+            Severity::Info,
+            "Writing as Parquet on Databricks foregoes Delta Lake ACID transactions, schema enforcement, and time travel",
+            "Use .format('delta') instead of .format('parquet') for analytical tables on Databricks",
+            1,
+            Confidence::Medium,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_readstream_no_trigger(source: &str) -> Vec<Finding> {
+    let has_readstream = source.contains("readStream") || source.contains("read_stream");
+    let has_start = source.contains(".start(");
+    let has_trigger = source.contains(".trigger(");
+    if has_readstream && has_start && !has_trigger {
+        vec![make_finding(
+            "BS002",
+            Severity::Warning,
+            "readStream without .trigger() runs in continuous micro-batch mode — add a trigger interval to control cost",
+            "Add .trigger(processingTime='1 minute') or .trigger(availableNow=True)",
+            1,
+            Confidence::Medium,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_stream_static_join_non_delta(source: &str) -> Vec<Finding> {
+    let has_readstream = source.contains("readStream") || source.contains("read_stream");
+    let has_join = source.contains(".join(");
+    if !has_readstream || !has_join {
+        return vec![];
+    }
+    // Look for spark.read (static side) using a non-Delta format.
+    // The readStream side may legitimately use delta; we only care about spark.read.
+    let static_read_parquet = source.contains("spark.read.format(\"parquet\")") || source.contains("spark.read.format('parquet')");
+    let static_read_csv = source.contains("spark.read.format(\"csv\")") || source.contains("spark.read.format('csv')")
+        || source.contains("spark.read.csv(");
+    let static_read_json = source.contains("spark.read.format(\"json\")") || source.contains("spark.read.format('json')")
+        || source.contains("spark.read.json(");
+    let static_read_orc = source.contains("spark.read.format(\"orc\")") || source.contains("spark.read.format('orc')");
+    if static_read_parquet || static_read_csv || static_read_json || static_read_orc {
+        vec![make_finding(
+            "BS006",
+            Severity::Warning,
+            "Stream-static join with a non-Delta static side does not automatically reflect updates to the static table",
+            "Use a Delta table for the static side so updates are visible without restarting the stream",
+            1,
+            Confidence::Low,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_self_join_no_alias(source: &str) -> Vec<Finding> {
+    if !source.contains(".join(") {
+        return vec![];
+    }
+    // Detect `x.join(x,` pattern — same variable name on both sides
+    let lines: Vec<&str> = source.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        // Simple heuristic: find `.join(var,` or `.join(var)` where var == the lhs object
+        if let Some(join_pos) = trimmed.find(".join(") {
+            let lhs = trimmed[..join_pos].trim();
+            // Extract the first argument of join
+            let after_open = &trimmed[join_pos + 6..];
+            let first_arg = after_open.split(|c: char| c == ',' || c == ')').next().unwrap_or("").trim();
+            if !lhs.is_empty() && !first_arg.is_empty() && lhs == first_arg {
+                return vec![make_finding(
+                    "BJ002",
+                    Severity::Warning,
+                    "Self-join without aliasing produces ambiguous column references",
+                    "Alias both sides: left = df.alias('left'); right = df.alias('right'); left.join(right, ...)",
+                    (i + 1) as u32,
+                    Confidence::High,
+                )];
+            }
+        }
+    }
+    vec![]
+}
+
+fn check_readstream_no_schema(source: &str) -> Vec<Finding> {
+    let has_readstream = source.contains("readStream") || source.contains("read_stream");
+    if !has_readstream {
+        return vec![];
+    }
+    let needs_schema = source.contains(".format(\"json\")") || source.contains(".format('json')")
+        || source.contains(".format(\"csv\")") || source.contains(".format('csv')")
+        || source.contains(".format(\"avro\")") || source.contains(".format('avro')");
+    let has_schema = source.contains(".schema(");
+    if needs_schema && !has_schema {
+        vec![make_finding(
+            "BP052",
+            Severity::Warning,
+            "readStream on JSON/CSV/Avro without an explicit schema triggers expensive inference on every restart",
+            "Provide .schema(my_schema) before .load() to avoid inference",
+            1,
+            Confidence::High,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_groupby_agg_filter(source: &str) -> Vec<Finding> {
+    // Detect .agg(...).filter( or .agg(...).where(
+    let has_agg = source.contains(".agg(");
+    let has_post_agg_filter = source.contains(".agg(") &&
+        (source.find(".filter(").unwrap_or(0) > source.find(".agg(").unwrap_or(usize::MAX)
+         || source.find(".where(").unwrap_or(0) > source.find(".agg(").unwrap_or(usize::MAX));
+    if has_agg && has_post_agg_filter {
+        vec![make_finding(
+            "BP072",
+            Severity::Info,
+            ".filter() after .agg() is a post-aggregation filter — ensure non-aggregated column filters are placed before groupBy for performance",
+            "Move filters on non-aggregated columns before groupBy(); keep filters on agg results after agg()",
+            1,
+            Confidence::Low,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_orderby_before_shuffle(source: &str) -> Vec<Finding> {
+    let orderby_pos = source.find(".orderBy(").or_else(|| source.find(".order_by("));
+    let shuffle_pos = source.find(".groupBy(")
+        .or_else(|| source.find(".join("))
+        .or_else(|| source.find(".repartition("));
+    if let (Some(ob), Some(sh)) = (orderby_pos, shuffle_pos) {
+        if ob < sh {
+            return vec![make_finding(
+                "BP073",
+                Severity::Warning,
+                ".orderBy() before a shuffle operation (groupBy/join/repartition) is discarded by the shuffle",
+                "Remove the pre-shuffle .orderBy(); apply sorting after the shuffle if order is required",
+                1,
+                Confidence::Medium,
+            )];
+        }
+    }
+    vec![]
+}
+
+fn check_single_withcolumn(source: &str) -> Vec<Finding> {
+    // Count occurrences of .withColumn( — fire if 3 or more in the same chain
+    let count = source.matches(".withColumn(").count();
+    if count >= 3 {
+        vec![make_finding(
+            "BP074",
+            Severity::Info,
+            "Multiple chained .withColumn() calls each add a Project node — use .withColumns({}) for efficiency",
+            "Replace chained .withColumn() calls with a single .withColumns({'col': expr, ...})",
+            1,
+            Confidence::Low,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_monotonically_increasing_id_join(source: &str) -> Vec<Finding> {
+    let has_mono_id = source.contains("monotonically_increasing_id");
+    let has_join = source.contains(".join(");
+    if has_mono_id && has_join {
+        vec![make_finding(
+            "BP090",
+            Severity::Warning,
+            "monotonically_increasing_id() used as a join key — IDs differ across recomputation and are not stable",
+            "Use a deterministic business key or a UUID derived from row content instead",
+            1,
+            Confidence::Medium,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_current_timestamp_in_cache(source: &str) -> Vec<Finding> {
+    let has_timestamp = source.contains("current_timestamp()") || source.contains("F.now()") || source.contains("functions.now()");
+    let has_cache = source.contains(".cache()") || source.contains(".persist(");
+    if has_timestamp && has_cache {
+        vec![make_finding(
+            "BP091",
+            Severity::Warning,
+            "current_timestamp() or now() inside a cached DataFrame returns the cache evaluation time, not query time",
+            "Materialise the timestamp before caching, or avoid caching DataFrames that include current_timestamp()/now()",
+            1,
+            Confidence::Medium,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_input_file_name_as_key(source: &str) -> Vec<Finding> {
+    let has_input_file = source.contains("input_file_name");
+    let used_as_key = source.contains(".join(") || source.contains(".partitionBy(");
+    if has_input_file && used_as_key {
+        vec![make_finding(
+            "BP094",
+            Severity::Warning,
+            "input_file_name() used as a partition or join key — file names vary by run, making results non-deterministic",
+            "Extract stable identifiers from file content rather than using input_file_name() as a key",
+            1,
+            Confidence::Medium,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_python_udf_photon(source: &str) -> Vec<Finding> {
+    // Detect Python UDFs (not pandas_udf which is Arrow-based and more Photon compatible)
+    let has_plain_udf = source.contains("@udf(") || source.contains("@udf\n")
+        || (source.contains("= udf(") && !source.contains("pandas_udf"));
+    let has_pandas_udf_only = source.contains("@pandas_udf") && !source.contains("@udf(") && !source.contains("= udf(");
+    if has_plain_udf && !has_pandas_udf_only {
+        vec![make_finding(
+            "BP100",
+            Severity::Warning,
+            "Python UDFs disable Photon acceleration — each row is serialized to Python and back",
+            "Rewrite using Spark built-in functions or use a Pandas UDF (Arrow-based) for better Photon compatibility",
+            1,
+            Confidence::High,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_photon_incompatible_expr(source: &str) -> Vec<Finding> {
+    if source.contains("from_xml(") || source.contains("to_xml(") {
+        vec![make_finding(
+            "BP102",
+            Severity::Info,
+            "from_xml() and to_xml() are not supported by Photon — the query falls back to the non-Photon engine",
+            "Pre-process XML with a pandas UDF or switch to JSON/Avro format for Photon-accelerated parsing",
+            1,
+            Confidence::High,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_broadcast_streaming(source: &str) -> Vec<Finding> {
+    let has_broadcast = source.contains("broadcast(");
+    let has_readstream = source.contains("readStream") || source.contains("read_stream");
+    if !has_broadcast || !has_readstream {
+        return vec![];
+    }
+    // Heuristic: broadcast( appears on the same line or close to readStream
+    let broadcast_pos = source.find("broadcast(").unwrap_or(usize::MAX);
+    let readstream_pos = source.find("readStream")
+        .or_else(|| source.find("read_stream"))
+        .unwrap_or(usize::MAX);
+    // Fire if broadcast wraps something near readStream (within 100 chars)
+    let distance = if broadcast_pos < readstream_pos {
+        readstream_pos - broadcast_pos
+    } else {
+        broadcast_pos - readstream_pos
+    };
+    if distance < 100 {
+        vec![make_finding(
+            "BP110",
+            Severity::Error,
+            "broadcast() applied to a streaming DataFrame causes a StreamingQueryException at runtime",
+            "Remove broadcast() from streaming DataFrames; Spark handles stream-static joins automatically",
+            1,
+            Confidence::Medium,
+        )]
+    } else {
+        vec![]
+    }
+}
+
+fn check_tojson_collect(source: &str) -> Vec<Finding> {
+    if source.contains(".toJSON().collect()") || source.contains(".toJSON().\ncollect()") {
+        vec![make_finding(
+            "BP112",
+            Severity::Warning,
+            ".toJSON().collect() pulls all rows as JSON strings to the driver — use .toPandas() or write to storage",
+            "Replace with df.toPandas().to_json() for small data, or df.write.format('json').save(path) for large data",
+            1,
+            Confidence::High,
+        )]
+    } else {
+        vec![]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -273,3 +897,4 @@ mod tests {
         assert!(findings.is_empty());
     }
 }
+

--- a/src/burnt-engine/src/rules/context.rs
+++ b/src/burnt-engine/src/rules/context.rs
@@ -16,6 +16,7 @@ fn get_dispatch() -> &'static HashMap<&'static str, ContextFn> {
         m.insert("BP021", check_jdbc_partition);
         m.insert("BP022", check_sdp_prohibited_ops);
         m.insert("BP023", check_window_without_partition);
+        m.insert("BQ004", check_correlated_subquery);
         m.insert("SDP006", check_materialized_view_incremental);
         m
     })
@@ -188,6 +189,46 @@ fn check_long_line(source: &str) -> Vec<Finding> {
     }
 
     findings
+}
+
+fn check_correlated_subquery(source: &str) -> Vec<Finding> {
+    let upper = source.to_uppercase();
+
+    // Must have NOT IN with a SELECT subquery
+    if !upper.contains("NOT IN") || !upper.contains("SELECT") {
+        return vec![];
+    }
+
+    // Correlation signal: the inner SELECT's WHERE clause contains a dotted column
+    // reference (e.g. outer_table.col = inner_table.col), typical of correlated subqueries.
+    // We look for NOT IN followed (within ~200 chars) by SELECT ... WHERE ... word.word
+    let not_in_positions: Vec<_> = upper.match_indices("NOT IN").collect();
+    for (pos, _) in not_in_positions {
+        let window = &source[pos..std::cmp::min(pos + 300, source.len())];
+        let window_upper = window.to_uppercase();
+        if window_upper.contains("SELECT") && window_upper.contains("WHERE") {
+            // Look for dotted identifier pattern (word.word) in the subquery window
+            let has_dot_ref = window
+                .split_whitespace()
+                .any(|tok| {
+                    let t = tok.trim_matches(|c: char| !c.is_alphanumeric() && c != '.' && c != '_');
+                    let parts: Vec<&str> = t.split('.').collect();
+                    parts.len() == 2 && parts.iter().all(|p| !p.is_empty() && p.chars().all(|c| c.is_alphanumeric() || c == '_'))
+                });
+            if has_dot_ref {
+                return vec![make_finding(
+                    "BQ004",
+                    Severity::Error,
+                    "Correlated subquery references outer columns — Spark may execute as a nested loop join",
+                    "Rewrite as a join or use window functions",
+                    1,
+                    Confidence::Medium,
+                )];
+            }
+        }
+    }
+
+    vec![]
 }
 
 #[cfg(test)]

--- a/src/burnt-engine/src/rules/dataflow.rs
+++ b/src/burnt-engine/src/rules/dataflow.rs
@@ -16,6 +16,8 @@ fn extract_action(line: &str) -> Option<&'static str> {
 pub fn check_dataflow_rules(rule_code: &str, source: &str) -> Vec<Finding> {
     match rule_code {
         "BP030" | "BP031" | "BP032" => check_cache_lifecycle(rule_code, source),
+        "BP060" => check_filter_after_cache(source),
+        "BNT-A02" => check_chained_select_alias(source),
         _ => vec![],
     }
 }
@@ -118,6 +120,76 @@ fn check_cache_lifecycle(rule_code: &str, source: &str) -> Vec<Finding> {
     }
 
     findings
+}
+
+fn check_filter_after_cache(source: &str) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    let lines: Vec<&str> = source.lines().collect();
+    // Track variable names that are directly assigned from .cache()
+    let mut cached_vars: HashMap<String, u32> = HashMap::new();
+
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        let line_num = (i + 1) as u32;
+
+        // Detect: `var = something.cache()`
+        if trimmed.contains(".cache()") {
+            let parts: Vec<&str> = trimmed.splitn(2, '=').collect();
+            if parts.len() == 2 {
+                let var = parts[0].trim().to_string();
+                if var.chars().next().map(|c| c.is_alphabetic()).unwrap_or(false) {
+                    cached_vars.insert(var, line_num);
+                }
+            }
+        }
+
+        // Detect: `cached_var.filter(...)` — filter on a cached variable
+        for (var, cache_line) in &cached_vars {
+            let filter_pat = format!("{}.filter(", var);
+            let where_pat = format!("{}.where(", var);
+            if trimmed.contains(&filter_pat) || trimmed.contains(&where_pat) {
+                findings.push(make_finding(
+                    "BP060",
+                    Severity::Warning,
+                    ".filter() on a cached DataFrame scans all cached data — cache after filtering instead",
+                    "Apply .filter() before .cache() so only the needed rows are materialised",
+                    *cache_line,
+                    Confidence::High,
+                ));
+                break;
+            }
+        }
+    }
+
+    findings
+}
+
+fn check_chained_select_alias(source: &str) -> Vec<Finding> {
+    // Count the number of `.select(` followed by `.alias(` patterns in the source
+    // Fire if there are 3+ consecutive `.select(...alias...)` calls
+    let mut chain_count = 0;
+    let mut pos = 0;
+    while let Some(sel_pos) = source[pos..].find(".select(") {
+        let abs = pos + sel_pos;
+        let snippet = &source[abs..std::cmp::min(abs + 200, source.len())];
+        if snippet.contains(".alias(") {
+            chain_count += 1;
+        } else {
+            chain_count = 0;
+        }
+        if chain_count >= 3 {
+            return vec![make_finding(
+                "BNT-A02",
+                Severity::Info,
+                "Multiple chained .select(...alias(...)) calls for renaming — consolidate into a single rename operation",
+                "Use .withColumnsRenamed({'old': 'new', ...}) or .toDF(*new_names) for batch renaming",
+                1,
+                Confidence::Medium,
+            )];
+        }
+        pos = abs + 8; // advance past ".select("
+    }
+    vec![]
 }
 
 #[cfg(test)]

--- a/src/burnt-engine/src/rules/dataflow.rs
+++ b/src/burnt-engine/src/rules/dataflow.rs
@@ -13,22 +13,26 @@ fn extract_action(line: &str) -> Option<&'static str> {
     None
 }
 
-pub fn check_dataflow_rules(source: &str) -> Vec<Finding> {
-    let mut all_findings = Vec::new();
+pub fn check_dataflow_rules(rule_code: &str, source: &str) -> Vec<Finding> {
+    match rule_code {
+        "BP030" | "BP031" | "BP032" => check_cache_lifecycle(rule_code, source),
+        _ => vec![],
+    }
+}
+
+fn check_cache_lifecycle(rule_code: &str, source: &str) -> Vec<Finding> {
+    let mut findings = Vec::new();
 
     let lines: Vec<&str> = source.lines().collect();
-    // BTreeSet gives sorted, deduplicated line numbers for free
     let mut cache_ops: HashMap<String, BTreeSet<u32>> = HashMap::new();
     let mut unpersist_ops: HashSet<String> = HashSet::new();
     let mut action_ops: HashMap<String, BTreeSet<u32>> = HashMap::new();
-    // Track all known DataFrame variable names to avoid rebuilding each iteration
     let mut known_dfs: HashSet<String> = HashSet::new();
 
     for (i, line) in lines.iter().enumerate() {
         let trimmed = line.trim();
         let line_num = (i + 1) as u32;
 
-        // Detect assignment patterns (var = ... .cache() / .unpersist() / action)
         let parts: Vec<&str> = trimmed.split('=').collect();
         if parts.len() >= 2 {
             let var_name = parts[0].trim();
@@ -39,49 +43,35 @@ pub fn check_dataflow_rules(source: &str) -> Vec<Finding> {
                 .unwrap_or(false)
             {
                 if trimmed.contains(".cache()") {
-                    cache_ops
-                        .entry(var_name.to_string())
-                        .or_default()
-                        .insert(line_num);
+                    cache_ops.entry(var_name.to_string()).or_default().insert(line_num);
                     known_dfs.insert(var_name.to_string());
                 } else if trimmed.contains(".unpersist()") {
                     unpersist_ops.insert(var_name.to_string());
                 } else if extract_action(trimmed).is_some() {
-                    action_ops
-                        .entry(var_name.to_string())
-                        .or_default()
-                        .insert(line_num);
+                    action_ops.entry(var_name.to_string()).or_default().insert(line_num);
                     known_dfs.insert(var_name.to_string());
                 }
             }
         }
 
-        // Check if any known DataFrame has a cache/unpersist/action call on this line
-        // (handles non-assignment forms like `df.cache()`)
         for df_name in &known_dfs {
             if trimmed.contains(&format!("{}.cache()", df_name)) {
-                cache_ops
-                    .entry(df_name.clone())
-                    .or_default()
-                    .insert(line_num);
+                cache_ops.entry(df_name.clone()).or_default().insert(line_num);
             } else if trimmed.contains(&format!("{}.unpersist()", df_name)) {
                 unpersist_ops.insert(df_name.clone());
             } else if extract_action(trimmed).is_some()
                 && trimmed.contains(&format!("{}.", df_name))
             {
-                action_ops
-                    .entry(df_name.clone())
-                    .or_default()
-                    .insert(line_num);
+                action_ops.entry(df_name.clone()).or_default().insert(line_num);
             }
         }
     }
 
-    for (df_name, lines) in &cache_ops {
-        let first_line = lines.iter().next().copied().unwrap_or(1);
+    for (df_name, cache_lines) in &cache_ops {
+        let first_line = cache_lines.iter().next().copied().unwrap_or(1);
 
-        if !unpersist_ops.contains(df_name) {
-            all_findings.push(make_finding(
+        if rule_code == "BP030" && !unpersist_ops.contains(df_name) {
+            findings.push(make_finding(
                 "BP030",
                 Severity::Warning,
                 ".cache() with no .unpersist() in the same scope — potential memory leak",
@@ -91,39 +81,43 @@ pub fn check_dataflow_rules(source: &str) -> Vec<Finding> {
             ));
         }
 
-        let act_count = action_ops.get(df_name).map(|s| s.len()).unwrap_or(0);
-        if act_count == 1 {
-            all_findings.push(make_finding(
-                "BP031",
-                Severity::Info,
-                ".cache() on a DataFrame used only once adds overhead with no benefit",
-                "Remove .cache() if the DataFrame is only used in one action",
-                first_line,
-                Confidence::Medium,
-            ));
-        }
-    }
-
-    for (df_name, action_lines) in &action_ops {
-        let act_count = action_lines.len();
-        if act_count >= 2 && !cache_ops.contains_key(df_name) {
-            for &ln in action_lines {
-                all_findings.push(make_finding(
-                    "BP032",
-                    Severity::Warning,
-                    &format!(
-                        "Same DataFrame has {} action calls without .cache() — plan executed multiple times",
-                        act_count
-                    ),
-                    "Call .cache() before the first action and .unpersist() afterward",
-                    ln,
-                    Confidence::High,
+        if rule_code == "BP031" {
+            let act_count = action_ops.get(df_name).map(|s| s.len()).unwrap_or(0);
+            if act_count == 1 {
+                findings.push(make_finding(
+                    "BP031",
+                    Severity::Info,
+                    ".cache() on a DataFrame used only once adds overhead with no benefit",
+                    "Remove .cache() if the DataFrame is only used in one action",
+                    first_line,
+                    Confidence::Medium,
                 ));
             }
         }
     }
 
-    all_findings
+    if rule_code == "BP032" {
+        for (df_name, action_lines) in &action_ops {
+            let act_count = action_lines.len();
+            if act_count >= 2 && !cache_ops.contains_key(df_name) {
+                for &ln in action_lines {
+                    findings.push(make_finding(
+                        "BP032",
+                        Severity::Warning,
+                        &format!(
+                            "Same DataFrame has {} action calls without .cache() — plan executed multiple times",
+                            act_count
+                        ),
+                        "Call .cache() before the first action and .unpersist() afterward",
+                        ln,
+                        Confidence::High,
+                    ));
+                }
+            }
+        }
+    }
+
+    findings
 }
 
 #[cfg(test)]
@@ -136,7 +130,7 @@ mod tests {
 cached_df = df.filter(col("x") > 10).cache()
 result = cached_df.collect()
 "#;
-        let findings = check_dataflow_rules(source);
+        let findings = check_dataflow_rules("BP030", source);
         let bp030: Vec<_> = findings.iter().filter(|f| f.code == "BP030").collect();
         assert!(!bp030.is_empty());
     }
@@ -147,7 +141,7 @@ result = cached_df.collect()
 cached_df = df.filter(col("x") > 10).cache()
 result = cached_df.collect()
 "#;
-        let findings = check_dataflow_rules(source);
+        let findings = check_dataflow_rules("BP031", source);
         let bp031: Vec<_> = findings.iter().filter(|f| f.code == "BP031").collect();
         assert!(!bp031.is_empty());
     }

--- a/src/burnt-engine/src/rules/mod.rs
+++ b/src/burnt-engine/src/rules/mod.rs
@@ -105,7 +105,7 @@ impl RulePipeline {
 
         for rule in &self.rules {
             if rule.has_dataflow && lang_matches(&rule.language, language) {
-                findings.extend(dataflow::check_dataflow_rules(source));
+                findings.extend(dataflow::check_dataflow_rules(&rule.code, source));
             }
         }
 


### PR DESCRIPTION
## Summary

- **Phase 1 (foundation):** Added `platform` field to all 44 existing rules (`all` / `databricks` / `delta`), created new rule family directories (`config/`, `streaming/`, `governance/`, `join/`, `observability/`, `testing/`), refactored `dataflow.rs` for per-rule dispatch, and fixed the BQ001/BQ004 overlap by narrowing BQ004 to a correlation-signal context check.
- **Phase 2 (31 Tier 1 tree-sitter rules):** AQE/config anti-patterns (BP040–BP046), I/O schema flags (BP050–BP053), API modernisation (BP070–BP071, BP101, BP111), observability hygiene (BO001–BO003), testing/security patterns (BT001–BT003), governance (BU002–BU004), and style rules (BNT-A01, BNT-A03, BNT-A04).
- **Phase 3 (33 Tier 2 context.rs rules):** Delta write semantics (BD010, BD013–BD014, BD020–BD022, BD026, BD032), Structured Streaming safety (BS001–BS006), Pandas interop (BP080–BP081), correctness/determinism (BP090–BP094), Photon compatibility (BP100, BP102, BP110, BP112), join correctness (BJ002, BJ004), governance (BU001), and performance patterns (BP042, BP052, BP072–BP074).
- **Phase 4 (2 Tier 3 dataflow rules):** BP060 (filter-after-cache) and BNT-A02 (chained select-alias renames).

## Test plan

- [ ] `cargo test` — 159 tests pass; only the 5 pre-existing DLT failures remain (unchanged)
- [ ] Verify new rules fire correctly on sample PySpark code for each category
- [ ] Confirm `platform = "databricks"` rules do not surface for OSS Spark users