### PR TITLE
Refactor CostEstimate to support multi-currency costs

### DIFF
--- a/src/burnt/cloud/__init__.py
+++ b/src/burnt/cloud/__init__.py
@@ -1,0 +1,10 @@
+"""Cloud pricing backend extras for burnt.
+
+Each sub-package implements ``PricingBackend`` for a specific cloud x runtime
+combination. Install the matching extra to enable dollar-cost mapping:
+
+    pip install burnt[azure-databricks]
+    pip install burnt[aws-databricks]
+    pip install burnt[gcp-databricks]
+    pip install burnt[onprem-spark]
+"""

--- a/src/burnt/cloud/aws_databricks/__init__.py
+++ b/src/burnt/cloud/aws_databricks/__init__.py
@@ -1,0 +1,1 @@
+"""AWS Databricks PricingBackend (stub — implementation ships with burnt[aws-databricks])."""

--- a/src/burnt/cloud/azure_databricks/__init__.py
+++ b/src/burnt/cloud/azure_databricks/__init__.py
@@ -1,0 +1,1 @@
+"""Azure Databricks PricingBackend (stub — implementation ships with burnt[azure-databricks])."""

--- a/src/burnt/cloud/gcp_databricks/__init__.py
+++ b/src/burnt/cloud/gcp_databricks/__init__.py
@@ -1,0 +1,1 @@
+"""GCP Databricks PricingBackend (stub — implementation ships with burnt[gcp-databricks])."""

--- a/src/burnt/cloud/onprem_spark/__init__.py
+++ b/src/burnt/cloud/onprem_spark/__init__.py
@@ -1,0 +1,1 @@
+"""On-premises Spark PricingBackend (stub — implementation ships with burnt[onprem-spark])."""

--- a/src/burnt/core/exceptions.py
+++ b/src/burnt/core/exceptions.py
@@ -77,10 +77,10 @@ class CostBudgetExceeded(BurntError):
         self.budget = budget
         self.currency = currency
         self.label = label
-        estimate_cost = estimate.estimated_cost_usd
+        estimate_cost = estimate.cost_in(currency) or estimate.primary_cost or 0
         msg = (
-            f"Estimated cost ${estimate_cost:.2f} exceeds "
-            f"budget {currency} ${budget:.2f}"
+            f"Estimated cost {currency} {estimate_cost:.2f} exceeds "
+            f"budget {currency} {budget:.2f}"
         )
         if label:
             msg += f" ({label})"

--- a/src/burnt/core/exchange.py
+++ b/src/burnt/core/exchange.py
@@ -3,8 +3,21 @@
 from datetime import date, timedelta
 from decimal import Decimal
 from functools import lru_cache
+from typing import Protocol
 
 from .exceptions import PricingError
+
+
+class ExchangeRateProvider(Protocol):
+    """Protocol for injectable exchange rate providers."""
+
+    def get_rate_for_amount(
+        self,
+        amount: Decimal,
+        target_date: date,
+        from_curr: str = "USD",
+        to_curr: str = "EUR",
+    ) -> Decimal: ...
 
 
 class FrankfurterProvider:
@@ -62,3 +75,13 @@ class FixedRateProvider:
         if from_curr == to_curr:
             return Decimal("1")
         return self._rate
+
+    def get_rate_for_amount(
+        self,
+        amount: Decimal,
+        target_date: date,
+        from_curr: str = "USD",
+        to_curr: str = "EUR",
+    ) -> Decimal:
+        """Convert amount at the fixed rate."""
+        return amount * self.get_rate(target_date, from_curr, to_curr)

--- a/src/burnt/core/models.py
+++ b/src/burnt/core/models.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import logging
 from decimal import Decimal  # noqa: TC003 — used in pydantic field type
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from burnt.core.exchange import ExchangeRateProvider
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 from tabulate import tabulate
@@ -174,78 +177,139 @@ class PricingInfo(BaseModel):
 
 
 class CostEstimate(BaseModel, _DisplayMixin):
-    """Cost estimate for a query or workload."""
+    """Cost estimate for a query or workload.
+
+    All currency amounts live in ``costs`` — a plain dict keyed by ISO 4217 code.
+    Use ``cost_in`` for a direct lookup (no I/O) and ``convert_to`` for live
+    conversion via an injectable ``ExchangeRateProvider``.
+    """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     estimated_dbu: float | None = None
-    estimated_cost_usd: float | None = None
-    estimated_cost_eur: float | None = None
+    costs: dict[str, float] = {}
     confidence: Confidence = Confidence.LOW
     breakdown: dict[str, float] = {}
     warnings: list[str] = []
     _cluster: ClusterConfig | None = PrivateAttr(default=None)
 
-    def raise_if_exceeds(
-        self, budget: float, label: str = "", currency: str | None = None
-    ) -> CostEstimate:
-        """Raise CostBudgetExceeded if cost exceeds budget. Returns self if under budget.
+    # ------------------------------------------------------------------
+    # Currency access
+    # ------------------------------------------------------------------
 
-        Args:
-            budget: Budget amount (in the specified currency).
-            label: Optional label for identifying this check in pipelines.
-            currency: Currency for the budget (USD, EUR, etc.). Uses default currency if not provided.
+    def cost_in(self, currency: str) -> float | None:
+        """Return the pre-computed cost in *currency*, or None if unavailable.
 
-        Returns:
-            self if under budget (chainable).
+        Pure dict lookup — no network calls, no conversion.
+        """
+        return self.costs.get(currency.upper())
+
+    def convert_to(
+        self,
+        currency: str,
+        exchange: ExchangeRateProvider | None = None,
+    ) -> float:
+        """Return cost in *currency*, converting via *exchange* if necessary.
+
+        Falls back to ``FrankfurterProvider`` (live Frankfurter API) when no
+        provider is supplied. Prefers USD as the conversion base; falls back
+        to the first available currency in ``costs``.
 
         Raises:
-            CostBudgetExceeded: If estimated cost exceeds the budget.
+            ValueError: If ``costs`` is empty.
         """
-        import warnings
         from datetime import date
         from decimal import Decimal
 
-        from burnt.core.exceptions import CostBudgetExceeded
         from burnt.core.exchange import FrankfurterProvider
+
+        code = currency.upper()
+        direct = self.cost_in(code)
+        if direct is not None:
+            return direct
+
+        if not self.costs:
+            raise ValueError("No cost data available for conversion")
+
+        provider = exchange if exchange is not None else FrankfurterProvider()
+        base = "USD" if "USD" in self.costs else next(iter(self.costs))
+        converted = provider.get_rate_for_amount(
+            Decimal(str(self.costs[base])),
+            date.today(),
+            from_curr=base,
+            to_curr=code,
+        )
+        return float(converted)
+
+    @property
+    def primary_cost(self) -> float | None:
+        """Best available cost amount, preferring major currencies in priority order."""
+        for code in ("USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF"):
+            if code in self.costs:
+                return self.costs[code]
+        return next(iter(self.costs.values()), None)
+
+    @property
+    def primary_currency(self) -> str | None:
+        """ISO 4217 code matching ``primary_cost``, or None if ``costs`` is empty."""
+        for code in ("USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF"):
+            if code in self.costs:
+                return code
+        return next(iter(self.costs), None)
+
+    # ------------------------------------------------------------------
+    # Budget guard
+    # ------------------------------------------------------------------
+
+    def raise_if_exceeds(
+        self, budget: float, label: str = "", currency: str | None = None
+    ) -> CostEstimate:
+        """Raise ``CostBudgetExceeded`` if cost exceeds *budget*; return self otherwise.
+
+        Args:
+            budget: Budget amount in *currency*.
+            label: Optional identifier surfaced in the exception message.
+            currency: ISO 4217 code (defaults to ``"USD"``).
+
+        Returns:
+            self — chainable.
+
+        Raises:
+            CostBudgetExceeded: When the estimated cost exceeds *budget*.
+        """
+        import warnings as _warnings
+
+        from burnt.core.exceptions import CostBudgetExceeded
 
         if currency is None:
             currency = "USD"
 
-        if self.estimated_cost_usd is None:
-            warnings.warn(
-                "Cannot check budget: estimated_cost_usd is None"
+        if not self.costs:
+            _warnings.warn(
+                "Cannot check budget: no cost data available"
                 + (f" for {label!r}" if label else ""),
                 stacklevel=2,
             )
             return self
 
-        estimate_currency = "USD"
-        if self.estimated_cost_eur is not None:
-            estimate_currency = "EUR"
-
-        if currency != estimate_currency:
-            exchange = FrankfurterProvider()
-            converted = exchange.get_rate_for_amount(
-                Decimal(str(budget)),
-                date.today(),
-                from_curr=currency,
-                to_curr=estimate_currency,
+        try:
+            estimate_cost = self.convert_to(currency)
+        except Exception:
+            _warnings.warn(
+                "Cannot check budget: currency conversion failed"
+                + (f" for {label!r}" if label else ""),
+                stacklevel=2,
             )
-            compare_budget = float(converted)
-        else:
-            compare_budget = budget
+            return self
 
-        estimate_cost = (
-            self.estimated_cost_eur
-            if estimate_currency == "EUR"
-            else self.estimated_cost_usd
-        )
-
-        if estimate_cost is not None and estimate_cost > compare_budget:
+        if estimate_cost > budget:
             raise CostBudgetExceeded(self, budget, label, currency=currency)
 
         return self
+
+    # ------------------------------------------------------------------
+    # Display
+    # ------------------------------------------------------------------
 
     def comparison_table(self) -> str:
         """Generate ASCII comparison table."""
@@ -256,8 +320,8 @@ class CostEstimate(BaseModel, _DisplayMixin):
         ]
         if self.estimated_dbu is not None:
             lines.append(f"{'Estimated DBU':<20} {self.estimated_dbu:<30.2f}")
-        if self.estimated_cost_usd is not None:
-            lines.append(f"{'Estimated Cost':<20} ${self.estimated_cost_usd:<29.2f}")
+        for code, amount in self.costs.items():
+            lines.append(f"{'Cost (' + code + ')':<20} {amount:<30.2f}")
         lines.append(f"{'Confidence':<20} {self.confidence:<30}")
 
         if self.breakdown:
@@ -278,8 +342,8 @@ class CostEstimate(BaseModel, _DisplayMixin):
         rows = []
         if self.estimated_dbu is not None:
             rows.append(["Estimated DBU", f"{self.estimated_dbu:.2f}"])
-        if self.estimated_cost_usd is not None:
-            rows.append(["Estimated Cost", f"${self.estimated_cost_usd:.2f}"])
+        for code, amount in self.costs.items():
+            rows.append([f"Cost ({code})", f"{amount:.2f}"])
         rows.append(["Confidence", self.confidence])
 
         md = tabulate(rows, headers=["Field", "Value"], tablefmt="github")
@@ -302,10 +366,11 @@ class CostEstimate(BaseModel, _DisplayMixin):
 
     def __repr__(self) -> str:
         """Return developer representation."""
-        cost = self.estimated_cost_usd or 0
+        cost = self.primary_cost or 0
+        currency = self.primary_currency or "USD"
         dbu = f"{self.estimated_dbu:.2f}" if self.estimated_dbu is not None else "N/A"
         return (
-            f"CostEstimate(dbu={dbu}, cost=${cost:.2f}, confidence={self.confidence})"
+            f"CostEstimate(dbu={dbu}, cost={currency} {cost:.2f}, confidence={self.confidence})"
         )
 
 
@@ -516,24 +581,26 @@ class SimulationResult(BaseModel, _DisplayMixin):
 
     def summary(self) -> str:
         """One-line summary description."""
-        original_cost = self.original.estimated_cost_usd or 0
-        projected_cost = self.projected.estimated_cost_usd or 0
+        original_cost = self.original.primary_cost or 0
+        projected_cost = self.projected.primary_cost or 0
+        currency = self.original.primary_currency or "USD"
         return (
             f"{', '.join(m.name for m in self.modifications)}: "
-            f"${original_cost:.2f} → ${projected_cost:.2f} ({self.total_savings_pct:+.1f}%)"
+            f"{currency} {original_cost:.2f} → {currency} {projected_cost:.2f} ({self.total_savings_pct:+.1f}%)"
         )
 
     def comparison_table(self) -> str:
         """Generate ASCII comparison table."""
-        original_cost = self.original.estimated_cost_usd or 0
-        projected_cost = self.projected.estimated_cost_usd or 0
+        original_cost = self.original.primary_cost or 0
+        projected_cost = self.projected.primary_cost or 0
+        currency = self.original.primary_currency or "USD"
 
         lines = [
             "Simulation Comparison",
             f"{'Metric':<20} {'Original':<15} {'Projected':<15} {'Δ':<10}",
             "-" * 60,
             f"{'DBU':<20} {self.original.estimated_dbu:<15.2f} {self.projected.estimated_dbu:<15.2f} {self.total_savings_pct:<10.1f}%",
-            f"{'Cost (USD)':<20} ${original_cost:<14.2f} ${projected_cost:<14.2f} {self.total_savings_pct:<10.1f}%",
+            f"{'Cost (' + currency + ')':<20} {original_cost:<15.2f} {projected_cost:<15.2f} {self.total_savings_pct:<10.1f}%",
             "",
             "Modifications:",
         ]
@@ -547,14 +614,15 @@ class SimulationResult(BaseModel, _DisplayMixin):
 
     def to_markdown(self) -> str:
         """Return a GFM markdown table using tabulate."""
-        original_cost = self.original.estimated_cost_usd or 0
-        projected_cost = self.projected.estimated_cost_usd or 0
+        original_cost = self.original.primary_cost or 0
+        projected_cost = self.projected.primary_cost or 0
+        currency = self.original.primary_currency or "USD"
 
         rows = [
             [
-                "Cost (USD)",
-                f"${original_cost:.2f}",
-                f"${projected_cost:.2f}",
+                f"Cost ({currency})",
+                f"{original_cost:.2f}",
+                f"{projected_cost:.2f}",
                 f"{self.total_savings_pct:.1f}%",
             ],
             [
@@ -617,12 +685,9 @@ class MultiSimulationResult(BaseModel, _DisplayMixin):
 
         def sort_key(item: tuple[str, SimulationResult]) -> tuple[float, int]:
             _name, result = item
-            cost = result.projected.estimated_cost_usd or float("inf")
+            cost = result.projected.primary_cost or float("inf")
             confidence_score = confidence_order.get(result.projected.confidence, 0)
-            return (
-                cost,
-                -confidence_score,
-            )  # Negative so higher confidence comes first
+            return (cost, -confidence_score)  # negative so higher confidence sorts first
 
         return min(self.scenarios, key=sort_key)
 
@@ -631,14 +696,15 @@ class MultiSimulationResult(BaseModel, _DisplayMixin):
         if not self.scenarios:
             return "No scenarios to compare."
 
+        first_currency = self.scenarios[0][1].projected.primary_currency or "USD"
         lines = [
             "Scenario Comparison",
-            f"{'Scenario':<20} {'Cost (USD)':<15} {'vs Baseline':<15} {'Modifications':<30}",
+            f"{'Scenario':<20} {'Cost (' + first_currency + ')':<15} {'vs Baseline':<15} {'Modifications':<30}",
             "-" * 80,
         ]
 
         for name, result in self.scenarios:
-            cost = result.projected.estimated_cost_usd or 0
+            cost = result.projected.primary_cost or 0
             vs_baseline = (
                 "—"
                 if name == self.scenarios[0][0]
@@ -649,7 +715,7 @@ class MultiSimulationResult(BaseModel, _DisplayMixin):
                 if result.modifications
                 else "—"
             )
-            lines.append(f"{name:<20} ${cost:<14.2f} {vs_baseline:<15} {mods:<30}")
+            lines.append(f"{name:<20} {cost:<15.2f} {vs_baseline:<15} {mods:<30}")
 
         return "\n".join(lines)
 
@@ -658,9 +724,10 @@ class MultiSimulationResult(BaseModel, _DisplayMixin):
         if not self.scenarios:
             return "No scenarios to compare."
 
+        first_currency = self.scenarios[0][1].projected.primary_currency or "USD"
         rows = []
         for name, result in self.scenarios:
-            cost = result.projected.estimated_cost_usd or 0
+            cost = result.projected.primary_cost or 0
             vs_baseline = (
                 "—"
                 if name == self.scenarios[0][0]
@@ -671,11 +738,11 @@ class MultiSimulationResult(BaseModel, _DisplayMixin):
                 if result.modifications
                 else "—"
             )
-            rows.append([name, f"${cost:.2f}", vs_baseline, mods])
+            rows.append([name, f"{cost:.2f}", vs_baseline, mods])
 
         return tabulate(
             rows,
-            headers=["Scenario", "Cost (USD)", "vs Baseline", "Modifications"],
+            headers=["Scenario", f"Cost ({first_currency})", "vs Baseline", "Modifications"],
             tablefmt="github",
         )
 

--- a/src/burnt/core/pricing.py
+++ b/src/burnt/core/pricing.py
@@ -1,8 +1,186 @@
-"""Pricing utilities for Azure Databricks."""
+"""Pricing protocol, currency constants, and Azure Databricks pricing utilities."""
+
+from __future__ import annotations
 
 from decimal import Decimal
+from typing import TYPE_CHECKING, Protocol
 
 from .exceptions import PricingError
+
+if TYPE_CHECKING:
+    from burnt.core.models import CostEstimate
+    from burnt.graph.model import CostGraph
+
+
+class PricingBackend(Protocol):
+    """Protocol every cloud pricing backend must satisfy.
+
+    Core ships no implementation — without a pricing extra, cost_estimate.cost_in()
+    returns None and only compute-seconds are reported.
+    """
+
+    name: str
+
+    def map(self, graph: CostGraph) -> CostEstimate:
+        """Map a CostGraph (compute-seconds) to a CostEstimate (dollars)."""
+        ...
+
+
+# ISO 4217 billing currency for each major cloud region identifier.
+CLOUD_REGION_CURRENCIES: dict[str, str] = {
+    # Azure
+    "eastus": "USD",
+    "eastus2": "USD",
+    "westus": "USD",
+    "westus2": "USD",
+    "westus3": "USD",
+    "centralus": "USD",
+    "northcentralus": "USD",
+    "southcentralus": "USD",
+    "northeurope": "EUR",
+    "westeurope": "EUR",
+    "uksouth": "GBP",
+    "ukwest": "GBP",
+    "japaneast": "JPY",
+    "japanwest": "JPY",
+    "canadacentral": "CAD",
+    "canadaeast": "CAD",
+    "australiaeast": "AUD",
+    "australiasoutheast": "AUD",
+    "australiacentral": "AUD",
+    "switzerlandnorth": "CHF",
+    "switzerlandwest": "CHF",
+    "brazilsouth": "BRL",
+    "brazilsoutheast": "BRL",
+    "koreacentral": "KRW",
+    "koreasouth": "KRW",
+    "southeastasia": "SGD",
+    "eastasia": "HKD",
+    "centralindia": "INR",
+    "southindia": "INR",
+    "westindia": "INR",
+    "swedencentral": "SEK",
+    "norwayeast": "NOK",
+    "norwaywest": "NOK",
+    "francesouth": "EUR",
+    "francecentral": "EUR",
+    "germanywestcentral": "EUR",
+    "polandcentral": "EUR",
+    "italynorth": "EUR",
+    "spaincentral": "EUR",
+    "mexicocentral": "MXN",
+    "newzealandnorth": "NZD",
+    "southafricanorth": "ZAR",
+    "uaenorth": "AED",
+    "israelcentral": "ILS",
+    # AWS
+    "us-east-1": "USD",
+    "us-east-2": "USD",
+    "us-west-1": "USD",
+    "us-west-2": "USD",
+    "eu-west-1": "EUR",
+    "eu-west-2": "GBP",
+    "eu-west-3": "EUR",
+    "eu-central-1": "EUR",
+    "eu-central-2": "CHF",
+    "eu-north-1": "SEK",
+    "eu-south-1": "EUR",
+    "eu-south-2": "EUR",
+    "ap-northeast-1": "JPY",
+    "ap-northeast-2": "KRW",
+    "ap-northeast-3": "JPY",
+    "ap-southeast-1": "SGD",
+    "ap-southeast-2": "AUD",
+    "ap-southeast-3": "IDR",
+    "ap-south-1": "INR",
+    "ap-south-2": "INR",
+    "ap-east-1": "HKD",
+    "ca-central-1": "CAD",
+    "ca-west-1": "CAD",
+    "sa-east-1": "BRL",
+    "me-south-1": "USD",
+    "me-central-1": "USD",
+    "af-south-1": "ZAR",
+    "il-central-1": "ILS",
+    # GCP
+    "us-central1": "USD",
+    "us-east1": "USD",
+    "us-east4": "USD",
+    "us-east5": "USD",
+    "us-west1": "USD",
+    "us-west2": "USD",
+    "us-west3": "USD",
+    "us-west4": "USD",
+    "us-south1": "USD",
+    "northamerica-northeast1": "CAD",
+    "northamerica-northeast2": "CAD",
+    "southamerica-east1": "BRL",
+    "southamerica-west1": "CLP",
+    "europe-west1": "EUR",
+    "europe-west2": "GBP",
+    "europe-west3": "EUR",
+    "europe-west4": "EUR",
+    "europe-west6": "CHF",
+    "europe-west8": "EUR",
+    "europe-west9": "EUR",
+    "europe-west10": "EUR",
+    "europe-west12": "EUR",
+    "europe-north1": "EUR",
+    "europe-central2": "PLN",
+    "europe-southwest1": "EUR",
+    "asia-east1": "TWD",
+    "asia-east2": "HKD",
+    "asia-northeast1": "JPY",
+    "asia-northeast2": "JPY",
+    "asia-northeast3": "KRW",
+    "asia-southeast1": "SGD",
+    "asia-southeast2": "IDR",
+    "asia-south1": "INR",
+    "asia-south2": "INR",
+    "australia-southeast1": "AUD",
+    "australia-southeast2": "AUD",
+    "me-west1": "USD",
+    "me-central1": "USD",
+    "me-central2": "SAR",
+    "africa-south1": "ZAR",
+}
+
+# All ISO 4217 currency codes that burnt pricing backends may report.
+SUPPORTED_CURRENCIES: frozenset[str] = frozenset(
+    {
+        "AED",
+        "AUD",
+        "BRL",
+        "CAD",
+        "CHF",
+        "CLP",
+        "CNY",
+        "DKK",
+        "EUR",
+        "GBP",
+        "HKD",
+        "IDR",
+        "ILS",
+        "INR",
+        "JPY",
+        "KRW",
+        "MXN",
+        "NOK",
+        "NZD",
+        "PLN",
+        "SAR",
+        "SEK",
+        "SGD",
+        "TWD",
+        "USD",
+        "ZAR",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Azure Databricks pricing utilities (used until azure-databricks extra ships)
+# ---------------------------------------------------------------------------
 
 AZURE_DBU_RATES = {
     "JOBS_COMPUTE": Decimal("0.30"),

--- a/src/burnt/graph/estimate.py
+++ b/src/burnt/graph/estimate.py
@@ -14,7 +14,7 @@ class CostEstimate(BaseModel):
     """Estimated cost for a workload."""
 
     estimated_dbu: float | None = None
-    estimated_cost_usd: float | None = None
+    costs: dict[str, float] = {}
     confidence: Literal["low", "medium", "high"] = "low"
     breakdown: dict[str, float] = {}
     warnings: list[str] = []

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -3,6 +3,7 @@ import warnings
 import pytest
 
 from burnt import CostBudgetExceeded
+from burnt.core.exchange import FixedRateProvider
 from burnt.core.models import (
     ClusterConfig,
     ClusterRecommendation,
@@ -91,24 +92,22 @@ class TestCostEstimate:
     def test_cost_estimate_creation(self):
         estimate = CostEstimate(
             estimated_dbu=100.0,
-            estimated_cost_usd=55.0,
+            costs={"USD": 55.0},
             confidence="high",
             breakdown={"complexity": 50.0},
             warnings=[],
         )
         assert estimate.estimated_dbu == 100.0
-        assert estimate.estimated_cost_usd == 55.0
+        assert estimate.costs["USD"] == 55.0
         assert estimate.confidence == "high"
 
     def test_cost_estimate_default_confidence(self):
         estimate = CostEstimate(estimated_dbu=10.0)
         assert estimate.confidence == "low"
 
-    def test_cost_estimate_optional_fields(self):
+    def test_cost_estimate_costs_empty_by_default(self):
         estimate = CostEstimate(estimated_dbu=100.0)
-        assert estimate.estimated_cost_usd is None
-        assert estimate.estimated_cost_eur is None
-        assert estimate.warnings == []
+        assert estimate.costs == {}
 
     def test_cost_estimate_confidence_values(self):
         for conf in ["low", "medium", "high"]:
@@ -117,6 +116,73 @@ class TestCostEstimate:
 
         with pytest.raises(ValueError):
             CostEstimate(estimated_dbu=10.0, confidence="invalid")
+
+    # ------------------------------------------------------------------
+    # cost_in / convert_to / primary_cost
+    # ------------------------------------------------------------------
+
+    def test_cost_in_returns_value_from_costs(self):
+        estimate = CostEstimate(costs={"USD": 50.0, "EUR": 46.0})
+        assert estimate.cost_in("USD") == 50.0
+        assert estimate.cost_in("EUR") == 46.0
+
+    def test_cost_in_is_case_insensitive(self):
+        estimate = CostEstimate(costs={"GBP": 42.0})
+        assert estimate.cost_in("gbp") == 42.0
+        assert estimate.cost_in("GBP") == 42.0
+
+    def test_cost_in_returns_none_for_missing_currency(self):
+        estimate = CostEstimate(costs={"USD": 50.0})
+        assert estimate.cost_in("JPY") is None
+
+    def test_cost_in_returns_none_on_empty_costs(self):
+        estimate = CostEstimate()
+        assert estimate.cost_in("USD") is None
+
+    def test_convert_to_direct_hit(self):
+        estimate = CostEstimate(costs={"USD": 50.0, "EUR": 46.0})
+        assert estimate.convert_to("EUR") == 46.0
+
+    def test_convert_to_uses_injected_exchange_provider(self):
+        from decimal import Decimal
+
+        estimate = CostEstimate(costs={"USD": 100.0})
+        provider = FixedRateProvider(Decimal("0.85"))
+        result = estimate.convert_to("EUR", exchange=provider)
+        assert abs(result - 85.0) < 0.01
+
+    def test_convert_to_raises_on_empty_costs(self):
+        estimate = CostEstimate()
+        with pytest.raises(ValueError, match="No cost data"):
+            estimate.convert_to("USD")
+
+    def test_primary_cost_prefers_usd(self):
+        estimate = CostEstimate(costs={"EUR": 46.0, "USD": 50.0, "GBP": 42.0})
+        assert estimate.primary_cost == 50.0
+        assert estimate.primary_currency == "USD"
+
+    def test_primary_cost_falls_back_to_eur(self):
+        estimate = CostEstimate(costs={"EUR": 46.0, "GBP": 42.0})
+        assert estimate.primary_cost == 46.0
+        assert estimate.primary_currency == "EUR"
+
+    def test_primary_cost_none_when_empty(self):
+        estimate = CostEstimate()
+        assert estimate.primary_cost is None
+        assert estimate.primary_currency is None
+
+    def test_comparison_table_shows_all_costs(self):
+        estimate = CostEstimate(costs={"USD": 50.0, "EUR": 46.0, "GBP": 42.0})
+        table = estimate.comparison_table()
+        assert "USD" in table
+        assert "EUR" in table
+        assert "GBP" in table
+
+    def test_comparison_table_no_costs(self):
+        estimate = CostEstimate(estimated_dbu=10.0)
+        table = estimate.comparison_table()
+        assert "Cost Estimate" in table
+        assert "Confidence" in table
 
 
 class TestClusterRecommendation:
@@ -156,17 +222,17 @@ class TestClusterRecommendation:
 
 class TestCostBudgetExceeded:
     def test_raise_if_exceeds_under_budget_returns_self(self):
-        estimate = CostEstimate(estimated_dbu=10.0, estimated_cost_usd=5.0)
+        estimate = CostEstimate(estimated_dbu=10.0, costs={"USD": 5.0})
         result = estimate.raise_if_exceeds(50.0)
         assert result is estimate
 
     def test_raise_if_exceeds_over_budget_raises(self):
-        estimate = CostEstimate(estimated_dbu=100.0, estimated_cost_usd=50.0)
+        estimate = CostEstimate(estimated_dbu=100.0, costs={"USD": 50.0})
         with pytest.raises(CostBudgetExceeded):
             estimate.raise_if_exceeds(10.0)
 
     def test_raise_if_exceeds_over_budget_exception_attributes(self):
-        estimate = CostEstimate(estimated_dbu=100.0, estimated_cost_usd=50.0)
+        estimate = CostEstimate(estimated_dbu=100.0, costs={"USD": 50.0})
         with pytest.raises(CostBudgetExceeded) as exc_info:
             estimate.raise_if_exceeds(10.0)
         assert exc_info.value.estimate is estimate
@@ -174,21 +240,21 @@ class TestCostBudgetExceeded:
         assert exc_info.value.currency == "USD"
 
     def test_raise_if_exceeds_label_in_message(self):
-        estimate = CostEstimate(estimated_dbu=100.0, estimated_cost_usd=50.0)
+        estimate = CostEstimate(estimated_dbu=100.0, costs={"USD": 50.0})
         with pytest.raises(CostBudgetExceeded) as exc_info:
             estimate.raise_if_exceeds(10.0, label="daily_agg")
         assert "daily_agg" in str(exc_info.value)
 
-    def test_raise_if_exceeds_none_cost_warns_and_returns_self(self):
+    def test_raise_if_exceeds_no_costs_warns_and_returns_self(self):
         estimate = CostEstimate(estimated_dbu=10.0)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             result = estimate.raise_if_exceeds(50.0)
             assert result is estimate
             assert len(w) == 1
-            assert "estimated_cost_usd is None" in str(w[0].message)
+            assert "no cost data" in str(w[0].message)
 
-    def test_raise_if_exceeds_none_cost_with_label_warns(self):
+    def test_raise_if_exceeds_no_costs_with_label_warns(self):
         estimate = CostEstimate(estimated_dbu=10.0)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -196,8 +262,19 @@ class TestCostBudgetExceeded:
             assert len(w) == 1
             assert "test_query" in str(w[0].message)
 
+    def test_raise_if_exceeds_non_usd_currency(self):
+        estimate = CostEstimate(costs={"GBP": 42.0})
+        with pytest.raises(CostBudgetExceeded) as exc_info:
+            estimate.raise_if_exceeds(10.0, currency="GBP")
+        assert exc_info.value.currency == "GBP"
+
+    def test_raise_if_exceeds_with_multiple_currencies(self):
+        estimate = CostEstimate(costs={"USD": 100.0, "EUR": 85.0})
+        with pytest.raises(CostBudgetExceeded):
+            estimate.raise_if_exceeds(50.0, currency="EUR")
+
     def test_raise_if_exceeds_chaining(self):
-        estimate = CostEstimate(estimated_dbu=10.0, estimated_cost_usd=5.0)
+        estimate = CostEstimate(estimated_dbu=10.0, costs={"USD": 5.0})
         result = estimate.raise_if_exceeds(50.0)
         assert result is estimate
-        assert result.estimated_cost_usd == 5.0
+        assert result.costs["USD"] == 5.0

--- a/tests/unit/core/test_pricing.py
+++ b/tests/unit/core/test_pricing.py
@@ -6,11 +6,97 @@ from burnt.core.exceptions import PricingError
 from burnt.core.pricing import (
     AZURE_DBU_RATES,
     AZURE_INSTANCE_DBU,
+    CLOUD_REGION_CURRENCIES,
+    SUPPORTED_CURRENCIES,
+    PricingBackend,
     apply_photon,
     compute_cost_usd,
     get_dbu_rate,
     usd_to_eur,
 )
+
+
+class TestPricingBackendProtocol:
+    def test_is_a_protocol(self):
+        import typing
+
+        assert issubclass(PricingBackend, typing.Protocol)
+
+    def test_has_name_annotation(self):
+        import typing
+
+        hints = typing.get_type_hints(PricingBackend)
+        assert "name" in hints
+
+    def test_has_map_method(self):
+        assert callable(getattr(PricingBackend, "map", None))
+
+    def test_structural_conformance(self):
+        from burnt.core.models import CostEstimate
+        from burnt.graph.model import CostGraph
+
+        class FakeBackend:
+            name = "test-backend"
+
+            def map(self, graph: CostGraph) -> CostEstimate:
+                return CostEstimate()
+
+        backend: PricingBackend = FakeBackend()
+        assert backend.name == "test-backend"
+
+
+class TestCloudRegionCurrencies:
+    def test_azure_regions_mapped(self):
+        assert CLOUD_REGION_CURRENCIES["eastus"] == "USD"
+        assert CLOUD_REGION_CURRENCIES["uksouth"] == "GBP"
+        assert CLOUD_REGION_CURRENCIES["japaneast"] == "JPY"
+        assert CLOUD_REGION_CURRENCIES["northeurope"] == "EUR"
+        assert CLOUD_REGION_CURRENCIES["canadacentral"] == "CAD"
+        assert CLOUD_REGION_CURRENCIES["australiaeast"] == "AUD"
+        assert CLOUD_REGION_CURRENCIES["switzerlandnorth"] == "CHF"
+
+    def test_aws_regions_mapped(self):
+        assert CLOUD_REGION_CURRENCIES["us-east-1"] == "USD"
+        assert CLOUD_REGION_CURRENCIES["eu-west-2"] == "GBP"
+        assert CLOUD_REGION_CURRENCIES["ap-northeast-1"] == "JPY"
+        assert CLOUD_REGION_CURRENCIES["ap-southeast-2"] == "AUD"
+        assert CLOUD_REGION_CURRENCIES["ca-central-1"] == "CAD"
+        assert CLOUD_REGION_CURRENCIES["sa-east-1"] == "BRL"
+
+    def test_gcp_regions_mapped(self):
+        assert CLOUD_REGION_CURRENCIES["us-central1"] == "USD"
+        assert CLOUD_REGION_CURRENCIES["europe-west2"] == "GBP"
+        assert CLOUD_REGION_CURRENCIES["europe-west6"] == "CHF"
+        assert CLOUD_REGION_CURRENCIES["asia-northeast1"] == "JPY"
+        assert CLOUD_REGION_CURRENCIES["australia-southeast1"] == "AUD"
+        assert CLOUD_REGION_CURRENCIES["northamerica-northeast1"] == "CAD"
+
+    def test_all_values_are_three_letter_codes(self):
+        for region, code in CLOUD_REGION_CURRENCIES.items():
+            assert len(code) == 3 and code.isupper(), (
+                f"Region {region!r} has invalid currency code {code!r}"
+            )
+
+
+class TestSupportedCurrencies:
+    def test_is_frozenset(self):
+        assert isinstance(SUPPORTED_CURRENCIES, frozenset)
+
+    def test_contains_major_currencies(self):
+        for code in ("USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF"):
+            assert code in SUPPORTED_CURRENCIES
+
+    def test_contains_emerging_market_currencies(self):
+        for code in ("BRL", "KRW", "SGD", "INR"):
+            assert code in SUPPORTED_CURRENCIES
+
+    def test_all_codes_are_three_letters(self):
+        for code in SUPPORTED_CURRENCIES:
+            assert len(code) == 3 and code.isupper(), f"Invalid code: {code!r}"
+
+    def test_is_immutable(self):
+        with pytest.raises(AttributeError):
+            SUPPORTED_CURRENCIES.add("XYZ")  # type: ignore[attr-defined]
 
 
 class TestAzureDbuRates:

--- a/tests/unit/test_cloud_stubs.py
+++ b/tests/unit/test_cloud_stubs.py
@@ -1,0 +1,42 @@
+"""Verify the cloud stub packages are importable and the PricingBackend is accessible."""
+
+
+class TestCloudStubImports:
+    def test_import_cloud_package(self):
+        import burnt.cloud  # noqa: F401
+
+    def test_import_azure_databricks(self):
+        import burnt.cloud.azure_databricks  # noqa: F401
+
+    def test_import_aws_databricks(self):
+        import burnt.cloud.aws_databricks  # noqa: F401
+
+    def test_import_gcp_databricks(self):
+        import burnt.cloud.gcp_databricks  # noqa: F401
+
+    def test_import_onprem_spark(self):
+        import burnt.cloud.onprem_spark  # noqa: F401
+
+
+class TestPricingBackendImportable:
+    def test_pricing_backend_importable(self):
+        from burnt.core.pricing import PricingBackend
+
+        assert PricingBackend is not None
+
+    def test_exchange_rate_provider_importable(self):
+        from burnt.core.exchange import ExchangeRateProvider
+
+        assert ExchangeRateProvider is not None
+
+    def test_cloud_region_currencies_importable(self):
+        from burnt.core.pricing import CLOUD_REGION_CURRENCIES
+
+        assert isinstance(CLOUD_REGION_CURRENCIES, dict)
+        assert len(CLOUD_REGION_CURRENCIES) > 0
+
+    def test_supported_currencies_importable(self):
+        from burnt.core.pricing import SUPPORTED_CURRENCIES
+
+        assert isinstance(SUPPORTED_CURRENCIES, frozenset)
+        assert len(SUPPORTED_CURRENCIES) > 0


### PR DESCRIPTION
## Summary

This PR refactors `CostEstimate` to support multiple currencies natively, replacing single-currency fields (`estimated_cost_usd`, `estimated_cost_eur`) with a flexible `costs` dictionary keyed by ISO 4217 codes. It introduces currency conversion capabilities, a `PricingBackend` protocol for cloud pricing implementations, and comprehensive region-to-currency mappings.

## Key Changes

### Core Model Refactoring
- **`CostEstimate` fields**: Replaced `estimated_cost_usd` and `estimated_cost_eur` with a `costs: dict[str, float]` field to support arbitrary currencies
- **Currency access methods**:
  - `cost_in(currency)` — direct dict lookup (no I/O)
  - `convert_to(currency, exchange)` — live conversion via injectable `ExchangeRateProvider`
  - `primary_cost` and `primary_currency` properties — prefer major currencies (USD → EUR → GBP → JPY → CAD → AUD → CHF)
- **Budget checking**: `raise_if_exceeds()` now uses `convert_to()` for flexible currency support and gracefully handles conversion failures

### Pricing Infrastructure
- **`PricingBackend` protocol** (`src/burnt/core/pricing.py`): Defines the interface all cloud pricing backends must implement (`name` attribute and `map(graph) → CostEstimate` method)
- **`CLOUD_REGION_CURRENCIES` mapping**: Comprehensive region-to-ISO-4217-code dictionary covering Azure, AWS, and GCP regions
- **`SUPPORTED_CURRENCIES` frozenset**: All currencies that burnt pricing backends may report (25 codes: USD, EUR, GBP, JPY, CAD, AUD, CHF, BRL, KRW, SGD, INR, etc.)
- **`ExchangeRateProvider` protocol** (`src/burnt/core/exchange.py`): Defines injectable exchange rate provider interface; `FixedRateProvider` now implements `get_rate_for_amount()`

### Display & Reporting
- Updated `comparison_table()`, `to_markdown()`, and `__repr__()` across `CostEstimate` and `SimulationResult` to display all currencies in `costs` and use `primary_currency` for formatting
- Removed hardcoded "$" symbols; now displays currency code (e.g., "USD 50.00")

### Cloud Stubs
- Created `src/burnt/cloud/` package structure with stubs for `azure_databricks`, `aws_databricks`, `gcp_databricks`, and `onprem_spark` (implementations ship with optional extras)

### Tests
- Added comprehensive tests for `cost_in()`, `convert_to()`, `primary_cost/currency` methods
- Updated budget-checking tests to use new `costs` dict
- Added tests for `PricingBackend` protocol, `CLOUD_REGION_CURRENCIES`, and `SUPPORTED_CURRENCIES`
- New `test_cloud_stubs.py` verifies cloud package imports and protocol accessibility

## Notable Implementation Details

- **Backward compatibility**: `CostEstimate` still accepts `estimated_dbu` and `confidence`; old single-currency fields are removed
- **Graceful degradation**: `convert_to()` defaults to `FrankfurterProvider` (live API) when no provider is injected; `raise_if_exceeds()` warns and returns self on conversion failure
- **Type safety**: Uses `TYPE_CHECKING` guards to avoid circular imports; `ExchangeRateProvider` and `PricingBackend` are structural protocols (duck-typing)
- **Currency normalization**: `cost_in()` and `convert_to()` accept case-insensitive currency codes (converted to uppercase)

https://claude.ai/code/session_015Y7ffqfbisz1FNNT8hjSEg